### PR TITLE
Updated wolfSSL-examples readmes

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ cd wolfssl-[version]
 Examples in this directory may be compiled using:
 
 ```
-cd ./dtls
+cd ./psk
 make
 ```
 
@@ -99,7 +99,7 @@ multi-threading.
 Examples in this directory may be compiled using:
 
 ```
-cd ./dtls
+cd ./tls
 make
 ```
 

--- a/psk/Makefile
+++ b/psk/Makefile
@@ -26,7 +26,7 @@ server-psk-nonblocking: server-psk-nonblocking.o
 	$(CC) -o $@ $^ $(CFLAGS) $(LIBS)
 
 server-psk-threaded: server-psk-threaded.o
-	$(CC) -o $@ $^ $(CFLAGS) $(LIBS)
+	$(CC) -o $@ $^ $(CFLAGS) $(LIBS) -lpthread
 
 .PHONY: clean all
 

--- a/wolfCLU/README.md
+++ b/wolfCLU/README.md
@@ -1,38 +1,45 @@
+#wolfCLU
+
 This is the wolfSSL:  Command Line Utility (wolfCLU).
-To use this feature, please configure wolfssl with the following line:
 
-'''
-./configure --enable-pwdbased --enable-opensslextra
-'''
+##wolfSSL Install
 
-The pwdbased is for password based encryption allowing the user
+To use this feature, please configure and install wolfssl with the following commands:
+
+    ./configure --enable-pwdbased --enable-opensslextra && make && make check
+
+If that succeeds, run:
+
+    sudo make install
+
+`--enable-pwdbased` is for password based encryption allowing the user
 to specify a unique password known only to him/her self and the
 recipient of the encrypted file.
 
-The opensslextra provides utility for a hex to binary conversion of
+`--enable-opensslextra` provides utility for a hex to binary conversion of
 hexidecimal values.
 
-other features that can be included when configuring wolfssl for
+Additional features that can be included when configuring wolfssl for
 encryption or decryption are:
 
         --enable-camellia
         --enable-des3
-
         --enable-blake2
         --enable-sha512
         --enable-fortress
 
-then run "./configure", "make", and "make install" for wolfssl root directory
-before using wolfCLU
+##wolfCLU Install
 
-After wolfssl is properly installed, to install wolfCLU:
-In the root directory (wolfssl-examples/wolfCLU) enter the following commands:
+After wolfssl is installed, install wolfCLU.  In the directory
+`wolfssl-examples/wolfCLU` enter the following commands:
+
     ./autogen.sh
     ./configure
     make
     sudo make install
 
 Now you should be able to use the wolfssl command line tool.  To verify type:
+
     wolfssl -h
 
 If everything worked, you should see the wolfssl help page.


### PR DESCRIPTION
Updated README in wolfSSL-examples to fix typos.  Originally, the instructions stated to cd into ./dlts for the psk and tls examples.

Updated wolfCLU README to clarify instructions and fix formatting.  Originally, the instructions contradicted itself by having the user configure wolfSSL twice with different options.  Removed the second configure instruction.

Updated the makefile under psk directory.  Originally, the make would fail because the -lpthread option wasn't there.