### PR TITLE
Cleanups for the PSK examples

### DIFF
--- a/psk/Makefile
+++ b/psk/Makefile
@@ -1,6 +1,11 @@
 CC=gcc
-CFLAGS=-Wall
-LIBS=-lwolfssl
+CFLAGS=-Wall -I/usr/local/include
+LIBS=-lwolfssl -lm -L/usr/local/lib
+
+# For debug (./configure --enable-debug --disable-shared)
+#LIBS=/usr/local/lib/libwolfssl.a
+#CFLAGS+=-g -DDEBUG
+
 
 all: client-tcp client-psk client-psk-nonblocking client-psk-resume server-tcp server-psk server-psk-nonblocking server-psk-threaded
 

--- a/psk/client-psk-nonblocking.c
+++ b/psk/client-psk-nonblocking.c
@@ -19,16 +19,18 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
  **/
 
-#include    <stdio.h>
-#include    <stdlib.h>
-#include    <string.h>
-#include    <errno.h>
-#include    <arpa/inet.h>
-#include    <signal.h>
-#include    <unistd.h>
-#include    <fcntl.h>
-#include    <sys/ioctl.h>
-#include    <wolfssl/ssl.h>  /* must include this to use wolfSSL security */
+#include <wolfssl/options.h> /* included for options sync */
+#include <wolfssl/ssl.h>     /* must include this to use wolfSSL security */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <errno.h>
+#include <arpa/inet.h>
+#include <signal.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <sys/ioctl.h>
 
 #define     MAXLINE 256      /* max text line length */
 #define     SERV_PORT 11111  /* default port*/

--- a/psk/client-psk-resume.c
+++ b/psk/client-psk-resume.c
@@ -20,14 +20,18 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
  **/
 
-#include    <stdio.h>
-#include    <stdlib.h>
-#include    <string.h>
-#include    <errno.h>
-#include    <arpa/inet.h>
-#include    <signal.h>
-#include    <unistd.h>
-#include    <wolfssl/ssl.h>  /* must include this to use wolfSSL security */
+#include <wolfssl/options.h> /* included for options sync */
+#include <wolfssl/ssl.h>     /* must include this to use wolfSSL security */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <errno.h>
+#include <arpa/inet.h>
+#include <signal.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <sys/ioctl.h>
 
 #define     MAXLINE 256      /* max text line length */
 #define     SERV_PORT 11111  /* default port*/

--- a/psk/client-psk.c
+++ b/psk/client-psk.c
@@ -20,14 +20,16 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
  **/
 
-#include    <stdio.h>
-#include    <stdlib.h>
-#include    <string.h>
-#include    <errno.h>
-#include    <arpa/inet.h>
-#include    <signal.h>
-#include    <unistd.h>
-#include    <wolfssl/ssl.h>  /* must include this to use wolfSSL security */
+#include <wolfssl/options.h> /* included for options sync */
+#include <wolfssl/ssl.h>     /* must include this to use wolfSSL security */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <errno.h>
+#include <arpa/inet.h>
+#include <signal.h>
+#include <unistd.h>
 
 #define     MAXLINE 256      /* max text line length */
 #define     SERV_PORT 11111  /* default port*/

--- a/psk/client-tcp.c
+++ b/psk/client-tcp.c
@@ -20,15 +20,15 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
  **/
 
-#include    <sys/socket.h>	/* basic socket definitions */
-#include    <netinet/in.h>	/* sockaddr_in{} and other Internet defns */
-#include    <stdio.h>
-#include    <stdlib.h>
-#include    <string.h>
-#include    <errno.h>
-#include    <arpa/inet.h>
-#include    <signal.h>
-#include    <unistd.h>
+#include <sys/socket.h>	/* basic socket definitions */
+#include <netinet/in.h>	/* sockaddr_in{} and other Internet defns */
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <errno.h>
+#include <arpa/inet.h>
+#include <signal.h>
+#include <unistd.h>
 
 #define     MAXLINE     256    /* max text line length */
 #define     SERV_PORT   11111

--- a/psk/server-psk-nonblocking.c
+++ b/psk/server-psk-nonblocking.c
@@ -20,7 +20,9 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
  */
 
-#include <wolfssl/ssl.h> /* include wolfssl security */
+#include <wolfssl/options.h> /* included for option sync */
+#include <wolfssl/ssl.h>     /* include wolfSSL security */
+
 #include <sys/socket.h>
 #include <netinet/in.h>
 #include <stdio.h>

--- a/psk/server-psk-threaded.c
+++ b/psk/server-psk-threaded.c
@@ -20,8 +20,9 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
  */
 
-#include <wolfssl/ssl.h>     /* include wolfSSL security */
 #include <wolfssl/options.h> /* included for option sync */
+#include <wolfssl/ssl.h>     /* include wolfSSL security */
+
 #include <pthread.h>        /* used for concurrent threading */
 #include <sys/socket.h>
 #include <netinet/in.h>

--- a/psk/server-psk.c
+++ b/psk/server-psk.c
@@ -20,8 +20,9 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
  */
 
-#include <wolfssl/ssl.h>     /* include wolfSSL security */
 #include <wolfssl/options.h> /* included for options sync */
+#include <wolfssl/ssl.h>     /* include wolfSSL security */
+
 #include <sys/socket.h>
 #include <netinet/in.h>
 #include <stdio.h>


### PR DESCRIPTION
Update the includes to use options.h then ssl.h. Updated and renamed the README.md to indicate that “WOLFSSL_STATIC_PSK” is required when building wolfSSL.