### PR TITLE
Fixes for TLS perf examples

### DIFF
--- a/tls/Makefile
+++ b/tls/Makefile
@@ -1,8 +1,14 @@
 # TLS Examples Makefile
 CC=gcc
-CFLAGS=-Wall
-LIBS=-lwolfssl -lm
+LIB_PATH=/usr/local
+CFLAGS=-Wall -I$(LIB_PATH)/include
+LIBS=-L$(LIB_PATH)/lib -lm
+DYN_LIB=-lwolfssl
+STATIC_LIB=$(LIB_PATH)/lib/libwolfssl.a
 DEBUG_FLAGS=-g -DDEBUG
+DEBUG_INC_PATHS=-MD
+OPTIMIZE=-Os
+
 
 # Intel QuickAssist
 QAT_PATH=../../QAT1.6
@@ -13,12 +19,15 @@ QAT_FLAGS=-DDO_CRYPTO -DUSER_SPACE \
 	-I$(QAT_PATH)/quickassist/utilities/osal/src/linux/user_space/include \
 	-I$(QAT_PATH)/quickassist/lookaside/access_layer/include \
 	-I$(QAT_PATH)/quickassist/lookaside/access_layer/src/common/include
-QAT_LIBS=-L$(QAT_PATH) -ladf_proxy -losal -licp_qa_al_s
+QAT_LIBS=-L$(QAT_PATH) -ladf_proxy -losal -licp_qa_al_s -lpthread
 
 # Options
 #CFLAGS+=$(DEBUG_FLAGS)
+CFLAGS+=$(OPTIMIZE)
 #CFLAGS+=$(QAT_FLAGS)
 #LIBS+=$(QAT_LIBS)
+#LIBS+=$(STATIC_LIB)
+LIBS+=$(DYN_LIB)
 
 
 # OS / CPU Detection

--- a/tls/client-tls-perf.c
+++ b/tls/client-tls-perf.c
@@ -212,6 +212,8 @@ static int SSL_Write(WOLFSSL* ssl, char* reply, int replyLen, int* totalBytes,
         return 2;
     if (error == SSL_ERROR_WANT_WRITE)
         return 3;
+    if (error == WC_PENDING_E)
+        return 4;
     if (error == 0)
         return 1;
 
@@ -980,8 +982,7 @@ int main(int argc, char* argv[])
                 printf("ERROR: failed in async polling\n");
                 break;
             }
-
-            if (ret == 1)
+            if (ret == 0)
                 continue;
         }
         sslConn->err = 0;


### PR DESCRIPTION
Fixed issue with server-tls-epll-threaded not doing wolfAsync_DevClose. Enhanced server-tls-epll-threaded to use the wolfAsync_DevOpenThread feature to assign thread and QuickAssist core affinity. Added “-a” option on servers to allow TLS version downgrade. Enhancements to the Makefile. Other various cleanups.