### PR TITLE
Added example that has the CA callback

### DIFF
--- a/tls/client-tls-cacb.c
+++ b/tls/client-tls-cacb.c
@@ -1,0 +1,208 @@
+/* client-tls-cacb.c
+ *
+ * Copyright (C) 2006-2015 wolfSSL Inc.
+ *
+ * This file is part of wolfSSL. (formerly known as CyaSSL)
+ *
+ * wolfSSL is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * wolfSSL is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
+ */
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <errno.h>
+#include <arpa/inet.h>
+
+#include <wolfssl/options.h>
+#include <wolfssl/ssl.h>          /* wolfSSL security library */
+#include <wolfssl/wolfcrypt/types.h>
+
+#define MAXDATASIZE  4096           /* maximum acceptable amount of data */
+#define SERV_PORT    11111          /* define default port number */
+
+const char* cert = "../certs/ca-cert.pem";
+
+/*
+ * clients initial contact with server. (socket to connect, security layer)
+ */
+int ClientGreet(int sock, WOLFSSL* ssl)
+{
+    /* data to send to the server, data recieved from the server */
+    char    sendBuff[MAXDATASIZE], rcvBuff[MAXDATASIZE] = {0};
+    int     ret = 0;                /* variable for error checking */
+
+    printf("Message for server:\t");
+    fgets(sendBuff, MAXDATASIZE, stdin);
+
+    if (wolfSSL_write(ssl, sendBuff, strlen(sendBuff)) != strlen(sendBuff)) {
+        /* the message is not able to send, or error trying */
+        ret = wolfSSL_get_error(ssl, 0);
+        printf("Write error: Error: %i\n", ret);
+        return EXIT_FAILURE;
+    }
+
+    if (wolfSSL_read(ssl, rcvBuff, MAXDATASIZE) < 0) {
+        /* the server failed to send data, or error trying */
+        ret = wolfSSL_get_error(ssl, 0);
+        printf("Read error. Error: %i\n", ret);
+        return EXIT_FAILURE;
+    }
+    printf("Recieved: \t%s\n", rcvBuff);
+
+    return ret;
+}
+
+static void CaCb(unsigned char* der, int sz, int type)
+{
+#ifdef OPENSSL_EXTRA
+    WOLFSSL_X509* x509;
+#endif
+
+    printf("CA cache add callback: derSz = %d, type = %d\n", sz, type);
+
+#ifdef OPENSSL_EXTRA
+    /* Load DER to Cert */
+    x509 = wolfSSL_X509_d2i(NULL, der, sz);
+    if (x509) {
+        char* altName;
+        char* issuer;
+        char* subject;
+        unsigned char serial[32];
+        int   ret;
+        int   sz = sizeof(serial);
+
+        WOLFSSL_X509_NAME* issureName = wolfSSL_X509_get_issuer_name(x509);
+        WOLFSSL_X509_NAME* subjectName = wolfSSL_X509_get_subject_name(x509);
+        issuer  = wolfSSL_X509_NAME_oneline(issureName, 0, 0);
+        subject = wolfSSL_X509_NAME_oneline(subjectName, 0, 0);
+
+        printf("\tIssuer : %s\n\tSubject: %s\n", issuer, subject);
+
+        while ( (altName = wolfSSL_X509_get_next_altname(x509)) != NULL) {
+            printf("\tAltName = %s\n", altName);
+        }
+
+        ret = wolfSSL_X509_get_serial_number(x509, serial, &sz);
+        if (ret == SSL_SUCCESS) {
+            int  i;
+            int  strLen;
+            char serialMsg[80];
+
+            /* testsuite has multiple threads writing to stdout, get output
+               message ready to write once */
+            strLen = sprintf(serialMsg, "\tSerial Number");
+            for (i = 0; i < sz; i++)
+                sprintf(serialMsg + strLen + (i*3), ":%02x ", serial[i]);
+            printf("%s\n", serialMsg);
+        }
+
+        XFREE(subject, 0, DYNAMIC_TYPE_OPENSSL);
+        XFREE(issuer,  0, DYNAMIC_TYPE_OPENSSL);
+
+        wolfSSL_X509_free(x509);
+    }
+#endif
+
+    (void)der;
+}
+
+/*
+ * applies TLS 1.2 security layer to data being sent.
+ */
+int Security(int sock)
+{
+    WOLFSSL_CTX* ctx;
+    WOLFSSL*     ssl;    /* create WOLFSSL object */
+    int         ret = 0;
+
+    wolfSSL_Init();      /* initialize wolfSSL */
+
+    /* create and initiLize WOLFSSL_CTX structure */
+    if ((ctx = wolfSSL_CTX_new(wolfTLSv1_2_client_method())) == NULL) {
+        printf("SSL_CTX_new error.\n");
+        return EXIT_FAILURE;
+    }
+
+    /* set callback for action when CA's are added */
+    wolfSSL_CTX_SetCACb(ctx, CaCb);
+
+    /* load CA certificates into wolfSSL_CTX. which will verify the server */
+    if (wolfSSL_CTX_load_verify_locations(ctx, cert, 0) != SSL_SUCCESS) {
+        printf("Error loading %s. Please check the file.\n", cert);
+        return EXIT_FAILURE;
+    }
+    if ((ssl = wolfSSL_new(ctx)) == NULL) {
+        printf("wolfSSL_new error.\n");
+        return EXIT_FAILURE;
+    }
+    wolfSSL_set_fd(ssl, sock);
+
+    ret = wolfSSL_connect(ssl);
+    if (ret == SSL_SUCCESS) {
+        ret = ClientGreet(sock, ssl);
+    }
+
+    /* frees all data before client termination */
+    wolfSSL_free(ssl);
+    wolfSSL_CTX_free(ctx);
+    wolfSSL_Cleanup();
+
+    return ret;
+}
+
+/*
+ * Command line argumentCount and argumentValues
+ */
+int main(int argc, char** argv)
+{
+    int     sockfd;                         /* socket file descriptor */
+    struct  sockaddr_in servAddr;           /* struct for server address */
+    int     ret = 0;                        /* variable for error checking */
+
+    if (argc != 2) {
+        /* if the number of arguments is not two, error */
+        printf("usage: ./client-tcp  <IP address>\n");
+        return EXIT_FAILURE;
+    }
+
+    /* internet address family, stream based tcp, default protocol */
+    sockfd = socket(AF_INET, SOCK_STREAM, 0);
+
+    if (sockfd < 0) {
+        printf("Failed to create socket. Error: %i\n", errno);
+        return EXIT_FAILURE;
+    }
+
+    memset(&servAddr, 0, sizeof(servAddr)); /* clears memory block for use */
+    servAddr.sin_family = AF_INET;          /* sets addressfamily to internet*/
+    servAddr.sin_port = htons(SERV_PORT);   /* sets port to defined port */
+
+    /* looks for the server at the entered address (ip in the command line) */
+    if (inet_pton(AF_INET, argv[1], &servAddr.sin_addr) < 1) {
+        /* checks validity of address */
+        ret = errno;
+        printf("Invalid Address. Error: %i\n", ret);
+        return EXIT_FAILURE;
+    }
+
+    if (connect(sockfd, (struct sockaddr *) &servAddr, sizeof(servAddr)) < 0) {
+        /* if socket fails to connect to the server*/
+        ret = errno;
+        printf("Connect error. Error: %i\n", ret);
+        return EXIT_FAILURE;
+    }
+    Security(sockfd);
+
+    return ret;
+}

--- a/tls/server-tls-epoll-perf.c
+++ b/tls/server-tls-epoll-perf.c
@@ -577,7 +577,7 @@ static int SSLConn_ReadWrite(SSLConn_CTX* ctx, SSLConn* sslConn)
  */
 static void SSLConn_PrintStats(SSLConn_CTX* ctx)
 {
-    fprintf(stderr, "wolfSSL Client Benchmark %d bytes\n"
+    fprintf(stderr, "wolfSSL Server Benchmark %d bytes\n"
             "\tNum Conns         : %9d\n"
             "\tTotal             : %9.3f ms\n"
             "\tTotal Avg         : %9.3f ms\n"

--- a/tls/server-tls-epoll-threaded.c
+++ b/tls/server-tls-epoll-threaded.c
@@ -685,7 +685,7 @@ static int SSLConn_ReadWrite(SSLConn_CTX* ctx, ThreadData* threadData,
  */
 static void SSLConn_PrintStats(SSLConn_CTX* ctx)
 {
-    fprintf(stderr, "wolfSSL Client Benchmark %d bytes\n"
+    fprintf(stderr, "wolfSSL Server Benchmark %d bytes\n"
             "\tNum Conns         : %9d\n"
             "\tTotal             : %9.3f ms\n"
             "\tTotal Avg         : %9.3f ms\n"


### PR DESCRIPTION
Added example that has the CA callback “wolfSSL_CTX_SetCACb” API and shows how to print information for the X509. This works only with OPENSSL_EXTRA defined. Fixed typo in server epoll examples.