### PR TITLE
Added wolfSSL_accept to TLS server examples

### DIFF
--- a/tls/server-tls-callback.c
+++ b/tls/server-tls-callback.c
@@ -151,6 +151,7 @@ int main()
     char               buff[256];
     size_t             len;
     int                shutdown = 0;
+    int                ret;
 
     /* declare wolfSSL objects */
     WOLFSSL_CTX* ctx;
@@ -246,6 +247,15 @@ int main()
 
         /* Attach wolfSSL to the socket */
         wolfSSL_set_fd(ssl, connd);
+
+        /* Establish TLS connection */
+        ret = wolfSSL_accept(ssl);
+        if (ret != SSL_SUCCESS) {
+            fprintf(stderr, "wolfSSL_accept error = %d\n",
+                wolfSSL_get_error(ssl, ret));
+            return -1;
+        }
+
 
         printf("Client connected successfully\n");
 

--- a/tls/server-tls-ecdhe.c
+++ b/tls/server-tls-ecdhe.c
@@ -53,6 +53,7 @@ int main()
     char               buff[256];
     size_t             len;
     int                shutdown = 0;
+    int                ret;
 
     /* declare wolfSSL objects */
     WOLFSSL_CTX* ctx;
@@ -149,8 +150,15 @@ int main()
         /* Attach wolfSSL to the socket */
         wolfSSL_set_fd(ssl, connd);
 
-        printf("Client connected successfully\n");
+        /* Establish TLS connection */
+        ret = wolfSSL_accept(ssl);
+        if (ret != SSL_SUCCESS) {
+            fprintf(stderr, "wolfSSL_accept error = %d\n",
+                wolfSSL_get_error(ssl, ret));
+            return -1;
+        }
 
+        printf("Client connected successfully\n");
 
 
         /* Read the client data into our buff array */
@@ -168,7 +176,6 @@ int main()
             printf("Shutdown command issued!\n");
             shutdown = 1;
         }
-
 
 
         /* Write our reply into buff */

--- a/tls/server-tls-nonblocking.c
+++ b/tls/server-tls-nonblocking.c
@@ -52,6 +52,7 @@ int main()
     char               buff[256];
     size_t             len;
     int                shutdown = 0;
+    int                ret;
 
     /* declare wolfSSL objects */
     WOLFSSL_CTX* ctx;
@@ -152,8 +153,15 @@ int main()
         /* Attach wolfSSL to the socket */
         wolfSSL_set_fd(ssl, connd);
 
-        printf("Client connected successfully\n");
+        /* Establish TLS connection */
+        ret = wolfSSL_accept(ssl);
+        if (ret != SSL_SUCCESS) {
+            fprintf(stderr, "wolfSSL_accept error = %d\n",
+                wolfSSL_get_error(ssl, ret));
+            return -1;
+        }
 
+        printf("Client connected successfully\n");
 
 
         /* Read the client data into our buff array */

--- a/tls/server-tls-threaded.c
+++ b/tls/server-tls-threaded.c
@@ -64,7 +64,7 @@ void* ClientHandler(void* args)
     WOLFSSL*         ssl;
     char             buff[256];
     size_t           len;
-
+    int              ret;
 
 
     /* Create a WOLFSSL object */
@@ -77,8 +77,16 @@ void* ClientHandler(void* args)
     /* Attach wolfSSL to the socket */
     wolfSSL_set_fd(ssl, pkg->connd);
 
-    printf("Client %d connected successfully\n", pkg->num);
+    /* Establish TLS connection */
+    ret = wolfSSL_accept(ssl);
+    if (ret != SSL_SUCCESS) {
+        fprintf(stderr, "wolfSSL_accept error = %d\n",
+            wolfSSL_get_error(ssl, ret));
+        pkg->open = 1;
+        pthread_exit(NULL);
+    }
 
+    printf("Client %d connected successfully\n", pkg->num);
 
 
     /* Read the client data into our buff array */

--- a/tls/server-tls.c
+++ b/tls/server-tls.c
@@ -51,6 +51,7 @@ int main()
     char               buff[256];
     size_t             len;
     int                shutdown = 0;
+    int                ret;
 
     /* declare wolfSSL objects */
     WOLFSSL_CTX* ctx;
@@ -140,6 +141,15 @@ int main()
 
         /* Attach wolfSSL to the socket */
         wolfSSL_set_fd(ssl, connd);
+
+        /* Establish TLS connection */
+        ret = wolfSSL_accept(ssl);
+        if (ret != SSL_SUCCESS) {
+            fprintf(stderr, "wolfSSL_accept error = %d\n",
+                wolfSSL_get_error(ssl, ret));
+            return -1;
+        }
+
 
         printf("Client connected successfully\n");
 


### PR DESCRIPTION
Even though its not explicitly required. Examples run correctly without the explicit wolfSSL_accept.