### PR TITLE
change file descriptors from socklen_t to int.

### DIFF
--- a/tls/client-tls-perf.c
+++ b/tls/client-tls-perf.c
@@ -741,16 +741,16 @@ static void WolfSSLCtx_Final(WOLFSSL_CTX* ctx)
  * socketfd  The connected socket.
  * returns EXIT_SUCCESS when the socket is connected and EXIT_FAILURE otherwise.
  */
-static int CreateSocketConnect(int port, socklen_t* socketfd)
+static int CreateSocketConnect(int port, int* socketfd)
 {
     int                on = 1;
     socklen_t          len = sizeof(on);
     struct sockaddr_in serverAddr = {0};
-    socklen_t          sockfd;
+    int                sockfd;
 
     /* Create a non-blocking socket to listen on for new connections. */
     sockfd = socket(AF_INET, SOCK_STREAM, 0);
-    if (sockfd == (socklen_t)-1) {
+    if (sockfd == -1) {
         fprintf(stderr, "ERROR: failed to create the socket\n");
         return EXIT_FAILURE;
     }
@@ -805,7 +805,7 @@ static void Usage(void)
  */
 int main(int argc, char* argv[])
 {
-    socklen_t    socketfd = -1;
+    int          socketfd = -1;
     int          ch;
     WOLFSSL_CTX* ctx = NULL;
     SSLConn_CTX* sslConnCtx;

--- a/tls/server-tcp.c
+++ b/tls/server-tcp.c
@@ -30,9 +30,9 @@
 
 #define DEFAULT_PORT 11111
 
-int AcceptAndRead(socklen_t sockfd);
+int AcceptAndRead(int sockfd);
 
-int AcceptAndRead(socklen_t sockfd)
+int AcceptAndRead(int sockfd)
 {
     struct sockaddr_in clientAddr;
  	socklen_t size = sizeof(clientAddr);
@@ -91,7 +91,7 @@ int main()
      */
 
      /* Identify and access the sockets */
-    socklen_t sockfd = socket(AF_INET, SOCK_STREAM, 0); 
+    int sockfd = socket(AF_INET, SOCK_STREAM, 0); 
     int exit   = 0; 	/* 0 = false, 1 = true */
 
     /* If positive value, the socket is valid */

--- a/tls/server-tls-ecdhe.c
+++ b/tls/server-tls-ecdhe.c
@@ -39,10 +39,10 @@
 
 #define DEFAULT_PORT 11111
 
-int AcceptAndRead(WOLFSSL_CTX* ctx, socklen_t sockfd, struct sockaddr_in
+int AcceptAndRead(WOLFSSL_CTX* ctx, int sockfd, struct sockaddr_in
     clientAddr);
 
-int AcceptAndRead(WOLFSSL_CTX* ctx, socklen_t sockfd, struct sockaddr_in
+int AcceptAndRead(WOLFSSL_CTX* ctx, int sockfd, struct sockaddr_in
     clientAddr)
 {
         /* Create our reply message */
@@ -50,7 +50,7 @@ int AcceptAndRead(WOLFSSL_CTX* ctx, socklen_t sockfd, struct sockaddr_in
     socklen_t         size    = sizeof(clientAddr);
 
     /* Wait until a client connects */
-    socklen_t connd = accept(sockfd, (struct sockaddr *)&clientAddr, &size);
+    int        connd = accept(sockfd, (struct sockaddr *)&clientAddr, &size);
 
     /* If fails to connect,int loop back up and wait for a new connection */
     if (connd == -1) {
@@ -121,7 +121,7 @@ int main()
      * Sets the type to be Stream based (TCP),
      * 0 means choose the default protocol.
      */
-    socklen_t sockfd   = socket(AF_INET, SOCK_STREAM, 0);
+    int sockfd   = socket(AF_INET, SOCK_STREAM, 0);
     int loopExit = 0; /* 0 = False, 1 = True */
     int ret      = 0; /* Return value */
     /* Server and client socket address structures */

--- a/tls/server-tls-epoll-perf.c
+++ b/tls/server-tls-epoll-perf.c
@@ -444,7 +444,7 @@ static int SSLConn_Done(SSLConn_CTX* ctx) {
  * otherwise.
  */
 static int SSLConn_Accept(SSLConn_CTX* ctx, WOLFSSL_CTX* sslCtx,
-                          socklen_t sockfd, SSLConn** sslConn)
+                          int sockfd, SSLConn** sslConn)
 {
     struct sockaddr_in clientAddr = {0};
     socklen_t          size = sizeof(clientAddr);
@@ -741,9 +741,9 @@ static void RandomReply(char* reply, int replyLen)
  * socketfd    The socket file descriptor to accept on.
  * returns EXIT_SUCCESS on success and EXIT_FAILURE otherwise.
  */
-static int CreateSocketListen(int port, int numClients, socklen_t* socketfd) {
+static int CreateSocketListen(int port, int numClients, int* socketfd) {
     int                 ret;
-    socklen_t           sockfd;
+    int                 sockfd;
     struct sockaddr_in  serverAddr = {0};
     int                 on = 1;
     socklen_t           len = sizeof(on);
@@ -756,7 +756,7 @@ static int CreateSocketListen(int port, int numClients, socklen_t* socketfd) {
 
     /* Create a non-blocking socket to listen on for new connections. */
     sockfd = socket(AF_INET, SOCK_STREAM, 0);
-    if (sockfd == (socklen_t)-1) {
+    if (sockfd == -1) {
         fprintf(stderr, "ERROR: failed to create the socket\n");
         return(EXIT_FAILURE);
     }
@@ -815,7 +815,7 @@ static void Usage(void)
 int main(int argc, char* argv[])
 {
     int                 ret = 0;
-    socklen_t           socketfd = -1;
+    int                 socketfd = -1;
     int                 efd;
     struct epoll_event  event;
     struct epoll_event  event_conn;

--- a/tls/server-tls-epoll-threaded.c
+++ b/tls/server-tls-epoll-threaded.c
@@ -557,7 +557,7 @@ static int SSLConn_Done(SSLConn_CTX* ctx) {
  * otherwise.
  */
 static int SSLConn_Accept(ThreadData* threadData, WOLFSSL_CTX* sslCtx,
-                          socklen_t sockfd, SSLConn** sslConn)
+                          int sockfd, SSLConn** sslConn)
 {
     struct sockaddr_in clientAddr = {0};
     socklen_t          size = sizeof(clientAddr);
@@ -829,9 +829,9 @@ static void WolfSSLCtx_Final(ThreadData* threadData)
  * socketfd    The socket file descriptor to accept on.
  * returns EXIT_SUCCESS on success and EXIT_FAILURE otherwise.
  */
-static int CreateSocketListen(int port, int numClients, socklen_t* socketfd) {
+static int CreateSocketListen(int port, int numClients, int* socketfd) {
     int                 ret;
-    socklen_t           sockfd;
+    int                 sockfd;
     struct sockaddr_in  serverAddr = {0};
     int                 on = 1;
     socklen_t           len = sizeof(on);
@@ -844,7 +844,7 @@ static int CreateSocketListen(int port, int numClients, socklen_t* socketfd) {
 
     /* Create a non-blocking socket to listen on for new connections. */
     sockfd = socket(AF_INET, SOCK_STREAM, 0);
-    if (sockfd == (socklen_t)-1) {
+    if (sockfd == -1) {
         fprintf(stderr, "ERROR: failed to create the socket\n");
         return(EXIT_FAILURE);
     }
@@ -879,7 +879,7 @@ static int CreateSocketListen(int port, int numClients, socklen_t* socketfd) {
 static void *ThreadHandler(void *data)
 {
     int                 ret;
-    socklen_t           socketfd = -1;
+    int                 socketfd = -1;
     int                 efd;
     struct epoll_event  event;
     struct epoll_event  event_conn;

--- a/tls/server-tls-nonblocking.c
+++ b/tls/server-tls-nonblocking.c
@@ -43,14 +43,14 @@
  */
 enum read_write_t {WRITE, READ, ACCEPT};
 
-int AcceptAndRead(WOLFSSL_CTX* ctx, socklen_t socketfd, 
+int AcceptAndRead(WOLFSSL_CTX* ctx, int socketfd, 
     struct sockaddr_in clientAddr);
-int TCPSelect(socklen_t socketfd);
-int NonBlocking_ReadWriteAccept(WOLFSSL* ssl, socklen_t socketfd, 
+int TCPSelect(int socketfd);
+int NonBlocking_ReadWriteAccept(WOLFSSL* ssl, int socketfd, 
     enum read_write_t rw);
 
 /*  Check if any sockets are ready for reading and writing and set it */
-int TCPSelect(socklen_t socketfd)
+int TCPSelect(int socketfd)
 {
     fd_set recvfds, errfds;
     int nfds = socketfd + 1;
@@ -75,7 +75,7 @@ int TCPSelect(socklen_t socketfd)
 }
 /* Checks if NonBlocking I/O is wanted, if it is wanted it will
  * wait until it's available on the socket before reading or writing */
-int NonBlocking_ReadWriteAccept(WOLFSSL* ssl, socklen_t socketfd, 
+int NonBlocking_ReadWriteAccept(WOLFSSL* ssl, int socketfd, 
     enum read_write_t rw)
 {
     const char reply[] = "I hear ya fa shizzle!\n";
@@ -144,7 +144,8 @@ int NonBlocking_ReadWriteAccept(WOLFSSL* ssl, socklen_t socketfd,
     return 1;
 }
 
-int AcceptAndRead(WOLFSSL_CTX* ctx, socklen_t socketfd, struct sockaddr_in clientAddr)
+int AcceptAndRead(WOLFSSL_CTX* ctx, int socketfd,
+        struct sockaddr_in clientAddr)
 {
     socklen_t     size = sizeof(clientAddr);
 
@@ -198,7 +199,7 @@ int main()
      * Sets the type to be Stream based (TCP),
      * 0 means choose the default protocol.
      */
-    socklen_t socketfd = socket(AF_INET, SOCK_STREAM, 0);
+    int socketfd = socket(AF_INET, SOCK_STREAM, 0);
     int loopExit = 0; /* 0 = False, 1 = True */
     int ret      = 0;
     int on       = 1;

--- a/tls/server-tls-threaded.c
+++ b/tls/server-tls-threaded.c
@@ -39,7 +39,7 @@
 
 #define DEFAULT_PORT 11111
 
-int  AcceptAndRead(socklen_t sockfd, struct sockaddr_in clientAddr);
+int  AcceptAndRead(int sockfd, struct sockaddr_in clientAddr);
 void *ThreadHandler(void* socketDesc);
 
 /* Create a ctx pointer for our ssl */
@@ -98,7 +98,7 @@ void *ThreadHandler(void* socketDesc)
 }
 
 
-int AcceptAndRead(socklen_t sockfd, struct sockaddr_in clientAddr)
+int AcceptAndRead(int sockfd, struct sockaddr_in clientAddr)
 {
     socklen_t size = sizeof(clientAddr);
     int connd;      /* Identify and access the clients connection */
@@ -130,7 +130,7 @@ int main()
      * Sets the type to be Stream based (TCP),
      * 0 means choose the default protocol.
      */
-    socklen_t sockfd   = socket(AF_INET, SOCK_STREAM, 0);
+    int sockfd   = socket(AF_INET, SOCK_STREAM, 0);
     int ret      = 0; /* Return Variable */
     int loopExit = 0; /* 0 = False, 1 = True */
 

--- a/tls/server-tls.c
+++ b/tls/server-tls.c
@@ -38,10 +38,10 @@
 
 #define DEFAULT_PORT 11111
 
-int AcceptAndRead(WOLFSSL_CTX* ctx, socklen_t sockfd, struct sockaddr_in
+int AcceptAndRead(WOLFSSL_CTX* ctx, int sockfd, struct sockaddr_in
     clientAddr);
 
-int AcceptAndRead(WOLFSSL_CTX* ctx, socklen_t sockfd, struct sockaddr_in
+int AcceptAndRead(WOLFSSL_CTX* ctx, int sockfd, struct sockaddr_in
     clientAddr)
 {
         /* Create our reply message */
@@ -49,7 +49,7 @@ int AcceptAndRead(WOLFSSL_CTX* ctx, socklen_t sockfd, struct sockaddr_in
     socklen_t         size    = sizeof(clientAddr);
 
     /* Wait until a client connects */
-    socklen_t connd = accept(sockfd, (struct sockaddr *)&clientAddr, &size);
+    int       connd = accept(sockfd, (struct sockaddr *)&clientAddr, &size);
 
     /* If fails to connect,int loop back up and wait for a new connection */
     if (connd == -1) {
@@ -119,7 +119,7 @@ int main()
      * Sets the type to be Stream based (TCP),
      * 0 means choose the default protocol.
      */
-    socklen_t sockfd   = socket(AF_INET, SOCK_STREAM, 0);
+    int sockfd   = socket(AF_INET, SOCK_STREAM, 0);
     int loopExit = 0; /* 0 = False, 1 = True */
     int ret      = 0; /* Return value */
     /* Server and client socket address structures */


### PR DESCRIPTION
At various points, file descriptors were of the socklen_t type, which I believe is an unsigned long. Because -1 is a possible value for a fildes (representing an error), socklen_t is not a suitable fit. For semantic reasons as well, a fildes shouldn't be a socklen_t.

This may cause conflicts with my other two pull requests, #47 and #48. I'm not completely sure, but if so, they should be simple fixes. Let me know if you need me to take care of these differences.