### PR TITLE
DTLS: Removed whitespace, fixed memset warning // Crypto: Fixed RNG memory leaks 

### DIFF
--- a/crypto/3des/3des-file-encrypt.c
+++ b/crypto/3des/3des-file-encrypt.c
@@ -19,10 +19,10 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
  */
 
+#include <wolfssl/options.h>
 #include <stdio.h>
 #include <unistd.h>
 #include <termios.h>
-#include <wolfssl/options.h>
 #include <wolfssl/wolfcrypt/des3.h>
 #include <wolfssl/wolfcrypt/sha256.h>
 #include <wolfssl/wolfcrypt/random.h>
@@ -46,7 +46,7 @@ int GenerateKey(RNG* rng, byte* key, int size, byte* salt, int pad)
         salt[0] = 0;            /* message is padded */
 
     /* stretches key */
-    ret = wc_PBKDF2(key, key, strlen((const char*)key), salt, SALT_SIZE, 4096, 
+    ret = wc_PBKDF2(key, key, strlen((const char*)key), salt, SALT_SIZE, 4096,
         size, SHA256);
     if (ret != 0)
         return -1030;
@@ -55,7 +55,7 @@ int GenerateKey(RNG* rng, byte* key, int size, byte* salt, int pad)
 }
 
 /*
- * Encrypts a file using 3DES 
+ * Encrypts a file using 3DES
  */
 int Des3Encrypt(Des3* des3, byte* key, int size, FILE* inFile, FILE* outFile)
 {
@@ -108,7 +108,7 @@ int Des3Encrypt(Des3* des3, byte* key, int size, FILE* inFile, FILE* outFile)
 
     /* stretches key to fit size */
     ret = GenerateKey(&rng, key, size, salt, padCounter);
-    if (ret != 0) 
+    if (ret != 0)
         return -1040;
 
     /* sets key */
@@ -135,12 +135,13 @@ int Des3Encrypt(Des3* des3, byte* key, int size, FILE* inFile, FILE* outFile)
     free(key);
     fclose(inFile);
     fclose(outFile);
+    wc_FreeRng(&rng);
 
     return 0;
 }
 
 /*
- * Decrypts a file using 3DES 
+ * Decrypts a file using 3DES
  */
 int Des3Decrypt(Des3* des3, byte* key, int size, FILE* inFile, FILE* outFile)
 {
@@ -218,6 +219,7 @@ int Des3Decrypt(Des3* des3, byte* key, int size, FILE* inFile, FILE* outFile)
     free(key);
     fclose(inFile);
     fclose(outFile);
+    wc_FreeRng(&rng);
 
     return 0;
 }

--- a/crypto/aes/aes-file-encrypt.c
+++ b/crypto/aes/aes-file-encrypt.c
@@ -134,6 +134,7 @@ int AesEncrypt(Aes* aes, byte* key, int size, FILE* inFile, FILE* outFile)
     free(key);
     fclose(inFile);
     fclose(outFile);
+    wc_FreeRng(&rng);
 
     return ret;
 }
@@ -217,6 +218,7 @@ int AesDecrypt(Aes* aes, byte* key, int size, FILE* inFile, FILE* outFile)
     free(key);
     fclose(inFile);
     fclose(outFile);
+    wc_FreeRng(&rng);
 
     return 0;
 }

--- a/crypto/camellia/camellia-encrypt.c
+++ b/crypto/camellia/camellia-encrypt.c
@@ -133,6 +133,7 @@ int CamelliaEncrypt(Camellia* cam, byte* key, int size, FILE* inFile,
     free(key);
     fclose(inFile);
     fclose(outFile);
+    wc_FreeRng(&rng);
 
     return 0;
 }
@@ -341,6 +342,6 @@ int main(int argc, char** argv)
     else if (choice == 'n') {
         printf("Must select either -e or -d for encryption and decryption\n");
     }
-
+    
     return ret;
 }

--- a/crypto/keys/ecc_keys.c
+++ b/crypto/keys/ecc_keys.c
@@ -63,7 +63,6 @@ int main()
     fclose(derFile);
     wc_ecc_free(&key);
 
-
     /* open and read from der file */
     printf("reading in private key\n");
     derFile = fopen("ecc-key.der", "rb");
@@ -118,7 +117,7 @@ int main()
     /* close stuff up */
     fclose(derFile);
     wc_ecc_free(&key);
-
+    wc_FreeRng(&rng);
     return 0;
 }
 

--- a/dtls/client-dtls-resume.c
+++ b/dtls/client-dtls-resume.c
@@ -1,5 +1,5 @@
-/* 
- * client-dtls-resume.c 
+/*
+ * client-dtls-resume.c
  *
  * Copyright (C) 2006-2015 wolfSSL Inc.
  *
@@ -24,9 +24,9 @@
  * Bare-bones example of a DTLS client for instructional/learning purposes.
  */
 
+#include <wolfssl/options.h>
 #include <unistd.h>
 #include <wolfssl/ssl.h>
-#include <wolfssl/options.h>
 #include <netdb.h>
 #include <signal.h>
 #include <sys/socket.h>
@@ -37,35 +37,35 @@
 #include <string.h>
 
 #define MAXLINE   4096
-#define SERV_PORT 11111 
+#define SERV_PORT 11111
 
 /* Send and receive function */
-void DatagramClient (WOLFSSL* ssl) 
+void DatagramClient (WOLFSSL* ssl)
 {
     int  n = 0;
     char sendLine[MAXLINE], recvLine[MAXLINE - 1];
 
     while (fgets(sendLine, MAXLINE, stdin) != NULL) {
-        
-       if ( ( wolfSSL_write(ssl, sendLine, strlen(sendLine))) != 
+
+       if ( (wolfSSL_write(ssl, sendLine, strlen(sendLine))) !=
 	      strlen(sendLine)) {
             printf("SSL_write failed");
         }
 
        n = wolfSSL_read(ssl, recvLine, sizeof(recvLine)-1);
-       
+
        if (n < 0) {
             int readErr = wolfSSL_get_error(ssl, 0);
 	        if(readErr != SSL_ERROR_WANT_READ)
 		        printf("wolfSSL_read failed");
        }
 
-        recvLine[n] = '\0';  
+        recvLine[n] = '\0';
         fputs(recvLine, stdout);
     }
 }
 
-int main (int argc, char** argv) 
+int main (int argc, char** argv)
 {
     int     		sockfd = 0;
     struct  		sockaddr_in servAddr;
@@ -77,14 +77,14 @@ int main (int argc, char** argv)
     char*    		srTest = "testing session resume";
     char            cert_array[] = "../certs/ca-cert.pem";
     char*           certs = cert_array;
-    if (argc != 2) { 
+    if (argc != 2) {
         printf("usage: udpcli <IP address>\n");
         return 1;
     }
 
     wolfSSL_Init();
     /* wolfSSL_Debugging_ON(); */
-   
+
     if ( (ctx = wolfSSL_CTX_new(wolfDTLSv1_2_client_method())) == NULL) {
         fprintf(stderr, "wolfSSL_CTX_new error.\n");
         return 1;
@@ -100,7 +100,7 @@ int main (int argc, char** argv)
     	printf("unable to get ssl object");
         return 1;
     }
-    
+
     memset(&servAddr, 0, sizeof(servAddr));
     servAddr.sin_family = AF_INET;
     servAddr.sin_port = htons(SERV_PORT);
@@ -110,12 +110,12 @@ int main (int argc, char** argv)
     }
 
     wolfSSL_dtls_set_peer(ssl, &servAddr, sizeof(servAddr));
-    
-    if ( (sockfd = socket(AF_INET, SOCK_DGRAM, 0)) < 0) { 
-       printf("cannot create a socket."); 
+
+    if ( (sockfd = socket(AF_INET, SOCK_DGRAM, 0)) < 0) {
+       printf("cannot create a socket.");
        return 1;
     }
-    
+
     wolfSSL_set_fd(ssl, sockfd);
     if (wolfSSL_connect(ssl) != SSL_SUCCESS) {
 	    int err1 = wolfSSL_get_error(ssl, 0);
@@ -124,7 +124,7 @@ int main (int argc, char** argv)
 	    printf("SSL_connect failed");
         return 1;
     }
-    
+
     DatagramClient(ssl);
     wolfSSL_write(ssl, srTest, sizeof(srTest));
     session = wolfSSL_get_session(ssl);
@@ -143,32 +143,34 @@ int main (int argc, char** argv)
     }
 
     wolfSSL_dtls_set_peer(sslResume, &servAddr, sizeof(servAddr));
-   
-    if ( (sockfd = socket(AF_INET, SOCK_DGRAM, 0)) < 0) { 
+
+    if ( (sockfd = socket(AF_INET, SOCK_DGRAM, 0)) < 0) {
         printf("cannot create a socket.");
         return 1;
-    } 
-    
+    }
+
     wolfSSL_set_fd(sslResume, sockfd);
     wolfSSL_set_session(sslResume, session);
 
-    if (wolfSSL_connect(sslResume) != SSL_SUCCESS) { 
+    if (wolfSSL_connect(sslResume) != SSL_SUCCESS) {
 	    printf("SSL_connect failed");
         return 1;
     }
 
-    if(wolfSSL_session_reused(sslResume))
+    if (wolfSSL_session_reused(sslResume)) {
     	printf("reused session id\n");
-    else
+    }
+    else {
     	printf("didn't reuse session id!!!\n");
-    
+    }
+
     DatagramClient(sslResume);
-    
+
     wolfSSL_write(sslResume, srTest, sizeof(srTest));
 
     wolfSSL_shutdown(sslResume);
     wolfSSL_free(sslResume);
-    
+
     close(sockfd);
     wolfSSL_CTX_free(ctx);
     wolfSSL_Cleanup();

--- a/dtls/client-dtls-shared.c
+++ b/dtls/client-dtls-shared.c
@@ -81,7 +81,8 @@ int dtls_recvfrom_cb(WOLFSSL* ssl, char* buf, int sz, void* ctx)
     if (!shared->handShakeDone) {
         /* get directly from socket */
         return recvfrom(shared->sd, buf, sz, 0, NULL, NULL);
-    } else {
+    }
+    else {
         /* get the "pushed" datagram from our cb buffer instead */
         int copied = min(sz, shared->recvSz);
 
@@ -265,4 +266,3 @@ int main (int argc, char** argv)
 
     return 0;
 }
-

--- a/dtls/client-dtls.c
+++ b/dtls/client-dtls.c
@@ -1,5 +1,5 @@
-/* 
- * client-dtls.c 
+/*
+ * client-dtls.c
  *
  * Copyright (C) 2006-2015 wolfSSL Inc.
  *
@@ -24,9 +24,9 @@
  * Bare-bones example of a DTLS client for instructional/learning purposes.
  */
 
+#include <wolfssl/options.h>
 #include <unistd.h>
 #include <wolfssl/ssl.h>
-#include <wolfssl/options.h>
 #include <netdb.h>
 #include <signal.h>
 #include <sys/socket.h>
@@ -37,23 +37,23 @@
 #include <string.h>
 
 #define MAXLINE   4096
-#define SERV_PORT 11111 
+#define SERV_PORT 11111
 
 /* Send and receive function */
-void DatagramClient (WOLFSSL* ssl) 
+void DatagramClient (WOLFSSL* ssl)
 {
     int  n = 0;
     char sendLine[MAXLINE], recvLine[MAXLINE - 1];
 
     while (fgets(sendLine, MAXLINE, stdin) != NULL) {
-    
-       if ( ( wolfSSL_write(ssl, sendLine, strlen(sendLine))) != 
+
+       if ( ( wolfSSL_write(ssl, sendLine, strlen(sendLine))) !=
 	      strlen(sendLine)) {
             printf("SSL_write failed");
         }
 
        n = wolfSSL_read(ssl, recvLine, sizeof(recvLine)-1);
-       
+
        if (n < 0) {
             int readErr = wolfSSL_get_error(ssl, 0);
 	        if(readErr != SSL_ERROR_WANT_READ) {
@@ -61,12 +61,12 @@ void DatagramClient (WOLFSSL* ssl)
             }
        }
 
-        recvLine[n] = '\0';  
+        recvLine[n] = '\0';
         fputs(recvLine, stdout);
     }
 }
 
-int main (int argc, char** argv)  
+int main (int argc, char** argv)
 {
     int     	sockfd = 0;
     struct  	sockaddr_in servAddr;
@@ -75,20 +75,20 @@ int main (int argc, char** argv)
     char        cert_array[]  = "../certs/ca-cert.pem";
     char*       certs = cert_array;
 
-    if (argc != 2) { 
+    if (argc != 2) {
         printf("usage: udpcli <IP address>\n");
         return 1;
     }
 
     wolfSSL_Init();
     /* wolfSSL_Debugging_ON(); */
-   
+
     if ( (ctx = wolfSSL_CTX_new(wolfDTLSv1_2_client_method())) == NULL) {
         fprintf(stderr, "wolfSSL_CTX_new error.\n");
         return 1;
     }
 
-    if (wolfSSL_CTX_load_verify_locations(ctx, certs, 0) 
+    if (wolfSSL_CTX_load_verify_locations(ctx, certs, 0)
 	    != SSL_SUCCESS) {
         fprintf(stderr, "Error loading %s, please check the file.\n", certs);
         return 1;
@@ -109,9 +109,9 @@ int main (int argc, char** argv)
     }
 
     wolfSSL_dtls_set_peer(ssl, &servAddr, sizeof(servAddr));
-    
-    if ( (sockfd = socket(AF_INET, SOCK_DGRAM, 0)) < 0) { 
-       printf("cannot create a socket."); 
+
+    if ( (sockfd = socket(AF_INET, SOCK_DGRAM, 0)) < 0) {
+       printf("cannot create a socket.");
        return 1;
     }
     wolfSSL_set_fd(ssl, sockfd);
@@ -121,7 +121,7 @@ int main (int argc, char** argv)
 	    printf("SSL_connect failed");
         return 1;
     }
- 
+
     DatagramClient(ssl);
 
     wolfSSL_shutdown(ssl);
@@ -132,4 +132,3 @@ int main (int argc, char** argv)
 
     return 0;
 }
-

--- a/dtls/client-udp.c
+++ b/dtls/client-udp.c
@@ -1,5 +1,5 @@
-/* 
- * client-udp.c 
+/*
+ * client-udp.c
  *
  * Copyright (C) 2006-2015 wolfSSL Inc.
  *
@@ -24,6 +24,7 @@
  * Bare-bones example of a UDP client for instructional/learning purposes.
  */
 
+#include <wolfssl/options.h>
 #include <sys/socket.h>
 #include <arpa/inet.h>
 #include <netinet/in.h>
@@ -35,7 +36,7 @@
 #define SERV_PORT 11111
 
 /* send and recieve message function */
-void DatagramClient (FILE* clientInput, int sockfd, 
+void DatagramClient (FILE* clientInput, int sockfd,
                      const struct sockaddr* servAddr, socklen_t servLen)
 {
 
@@ -43,18 +44,18 @@ void DatagramClient (FILE* clientInput, int sockfd,
     char sendLine[MAXLINE], recvLine[MAXLINE +1];
 
     while (fgets(sendLine, MAXLINE, clientInput) != NULL) {
-        
-       if ( ( sendto(sockfd, sendLine, strlen(sendLine) - 1, 0, servAddr, 
+
+       if ( ( sendto(sockfd, sendLine, strlen(sendLine) - 1, 0, servAddr,
               servLen)) == -1) {
             printf("error in sending");
         }
 
 
        if ( (n = recvfrom(sockfd, recvLine, MAXLINE, 0, NULL, NULL)) == -1) {
-             printf("Error in receiving");   
+             printf("Error in receiving");
         }
 
-        recvLine[n] = 0;  
+        recvLine[n] = 0;
         fputs(recvLine, stdout);
     }
 }
@@ -64,7 +65,7 @@ int main(int argc, char** argv)
 
     int    sockfd;
     struct sockaddr_in servAddr;
-    
+
     if (argc != 2) {
         printf("usage: udpcli <IP address>\n");
         return 1;
@@ -73,14 +74,15 @@ int main(int argc, char** argv)
     if ( (sockfd = socket(AF_INET, SOCK_DGRAM, 0)) < 0) {
        printf("cannot create a socket.");
        return 1;
-    } 
+    }
 
-    memset(&servAddr, sizeof(servAddr), 0);
+    memset(&servAddr, 0, sizeof(servAddr));
+
     servAddr.sin_family = AF_INET;
     servAddr.sin_port = htons(SERV_PORT);
     inet_pton(AF_INET, argv[1], &servAddr.sin_addr);
 
-    DatagramClient(stdin, sockfd, (struct sockaddr*) &servAddr, 
+    DatagramClient(stdin, sockfd, (struct sockaddr*) &servAddr,
                    sizeof(servAddr));
 
     return 0;

--- a/dtls/server-dtls-nonblocking.c
+++ b/dtls/server-dtls-nonblocking.c
@@ -1,4 +1,4 @@
-/* server-dtls-nonblocking.c 
+/* server-dtls-nonblocking.c
  *
  * Copyright (C) 2006-2015 wolfSSL Inc.
  *
@@ -20,10 +20,11 @@
  *
  *=============================================================================
  *
- * Bare-bones example of a nonblocking DTLS erver for instructional/learning purposes.
- * Utilizes DTLS 1.2.
+ * Bare-bones example of a nonblocking DTLS erver for instructional/learning
+ * purposes. Utilizes DTLS 1.2.
  */
 
+#include <wolfssl/options.h>
 #include <stdio.h>                  /* standard in/out procedures */
 #include <stdlib.h>                 /* defines system calls */
 #include <string.h>                 /* necessary for memset */
@@ -61,7 +62,7 @@ int AwaitDGram(WOLFSSL_CTX* ctx)
     int     on = 1;
     int     res = 1;
     int     recvLen;                 /* length of string read */
-    int     readWriteErr; 
+    int     readWriteErr;
     int     listenfd = 0;            /* Initialize our socket */
     int     clientfd = 0;            /* client connection */
     int     len = sizeof(on);
@@ -78,9 +79,9 @@ int AwaitDGram(WOLFSSL_CTX* ctx)
             printf("Cannot create socket.\n");
             return 1;
         }
-        
+
         printf("Socket allocated\n");
-        
+
         dtls_set_nonblocking(&listenfd);
 
         memset((char *)&servAddr, 0, sizeof(servAddr));
@@ -99,19 +100,19 @@ int AwaitDGram(WOLFSSL_CTX* ctx)
         }
 
         /*Bind Socket*/
-        if (bind(listenfd, 
+        if (bind(listenfd,
                     (struct sockaddr *)&servAddr, sizeof(servAddr)) < 0) {
             printf("Bind failed.\n");
             return 1;
         }
 
         printf("Awaiting client connection on port %d\n", SERV_PORT);
-        
-        
-        clientfd = udp_read_connect(listenfd);
-     
 
-//        dtls_set_nonblocking(&clientfd);
+
+        clientfd = udp_read_connect(listenfd);
+
+
+        /* dtls_set_nonblocking(&clientfd); */
 
         /* Create the WOLFSSL Object */
         if (( ssl = wolfSSL_new(ctx)) == NULL) {
@@ -135,7 +136,7 @@ int AwaitDGram(WOLFSSL_CTX* ctx)
 
         /* Begin: Reply to the client */
         recvLen = wolfSSL_read(ssl, buff, sizeof(buff)-1);
-        
+
         /* Begin do-while read */
         do {
             if (cleanup == 1) {
@@ -147,23 +148,24 @@ int AwaitDGram(WOLFSSL_CTX* ctx)
                 if (readWriteErr != SSL_ERROR_WANT_READ) {
                     printf("Read Error, error was: %d.\n", readWriteErr);
                     cleanup = 1;
-                } else {
+                }
+                else {
                     recvLen = wolfSSL_read(ssl, buff, sizeof(buff)-1);
                 }
             }
-        } while (readWriteErr == SSL_ERROR_WANT_READ && 
-                                         recvLen < 0 && 
+        } while (readWriteErr == SSL_ERROR_WANT_READ &&
+                                         recvLen < 0 &&
                                          cleanup != 1);
         /* End do-while read */
 
         if (recvLen > 0) {
             buff[recvLen] = 0;
             printf("I heard this:\"%s\"\n", buff);
-        } 
+        }
         else {
             printf("Connection Timed Out.\n");
         }
-        
+
         /* Begin do-while write */
         do {
             if (cleanup == 1) {
@@ -176,7 +178,7 @@ int AwaitDGram(WOLFSSL_CTX* ctx)
                 cleanup = 1;
             }
             printf("Reply sent:\"%s\"\n", ack);
-        }while(readWriteErr == SSL_ERROR_WANT_WRITE && cleanup != 1);
+        } while(readWriteErr == SSL_ERROR_WANT_WRITE && cleanup != 1);
         /* End do-while write */
 
         /* free allocated memory */
@@ -201,7 +203,7 @@ int udp_read_connect(int listenfd)
     } while (bytesRecvd <= 0);
 
     if (bytesRecvd > 0) {
-        if (connect(listenfd, (const struct sockaddr*)&cliAddr, 
+        if (connect(listenfd, (const struct sockaddr*)&cliAddr,
                     sizeof(cliAddr)) != 0) {
             printf("udp connect failed.\n");
         }
@@ -224,7 +226,7 @@ int NonBlockingSSL_Accept(WOLFSSL* ssl)
     int error = wolfSSL_get_error(ssl, 0);
     int listenfd = (int)wolfSSL_get_fd(ssl);
 
-    while (cleanup != 1 && (ret != SSL_SUCCESS && 
+    while (cleanup != 1 && (ret != SSL_SUCCESS &&
                 (error == SSL_ERROR_WANT_READ ||
                  error == SSL_ERROR_WANT_WRITE))) {
         if (cleanup == 1) {
@@ -271,8 +273,8 @@ void dtls_set_nonblocking(int* sockfd)
     if (flags < 0) {
         printf("fcntl get failed");
         cleanup = 1;
-    }            
-    flags = fcntl(*sockfd, F_SETFL, flags | O_NONBLOCK);            
+    }
+    flags = fcntl(*sockfd, F_SETFL, flags | O_NONBLOCK);
     if (flags < 0) {
         printf("fcntl set failed.\n");
         cleanup = 1;
@@ -293,13 +295,16 @@ int dtls_select(int socketfd, int toSec)
 
     result = select(nfds, &recvfds, NULL, &errfds, &timeout);
 
-    if (result == 0)
+    if (result == 0) {
         return TEST_TIMEOUT;
+    }
     else if (result > 0) {
-        if (FD_ISSET(socketfd, &recvfds))
+        if (FD_ISSET(socketfd, &recvfds)) {
             return TEST_RECV_READY;
-        else if(FD_ISSET(socketfd, &errfds))
+        }
+        else if(FD_ISSET(socketfd, &errfds)) {
             return TEST_ERROR_READY;
+        }
     }
 
     return TEST_SELECT_FAIL;
@@ -307,7 +312,7 @@ int dtls_select(int socketfd, int toSec)
 
 int main(int argc, char** argv)
 {
-    /* cont short for "continue?", Loc short for "location" */    
+    /* cont short for "continue?", Loc short for "location" */
     int         cont = 0;
     char        caCertLoc[] = "../certs/ca-cert.pem";
     char        servCertLoc[] = "../certs/server-cert.pem";
@@ -326,7 +331,7 @@ int main(int argc, char** argv)
         return 1;
     }
     /* Load CA certificates */
-    if (wolfSSL_CTX_load_verify_locations(ctx,caCertLoc,0) != 
+    if (wolfSSL_CTX_load_verify_locations(ctx,caCertLoc,0) !=
             SSL_SUCCESS) {
         printf("Error loading %s, please check the file.\n", caCertLoc);
         return 1;
@@ -338,7 +343,7 @@ int main(int argc, char** argv)
         return 1;
     }
     /* Load server Keys */
-    if (wolfSSL_CTX_use_PrivateKey_file(ctx, servKeyLoc, 
+    if (wolfSSL_CTX_use_PrivateKey_file(ctx, servKeyLoc,
                 SSL_FILETYPE_PEM) != SSL_SUCCESS) {
         printf("Error loading %s, please check the file.\n", servKeyLoc);
         return 1;

--- a/dtls/server-dtls-threaded.c
+++ b/dtls/server-dtls-threaded.c
@@ -20,11 +20,11 @@
  *
  *=============================================================================
  *
- * Bare-bones example of a threaded DTLS server for instructional/learning purposes.
- * Utilizes DTLS 1.2. and multi-threading
+ * Bare-bones example of a threaded DTLS server for instructional/learning
+ * purposes. Utilizes DTLS 1.2. and multi-threading
  */
 
-
+#include <wolfssl/options.h>
 #include <stdio.h>                  /* standard in/out procedures */
 #include <stdlib.h>                 /* defines system calls */
 #include <string.h>                 /* necessary for memset */
@@ -53,7 +53,7 @@ typedef struct {
     int activefd;
     int size;
     unsigned char b[MSGLEN];
-}threadArgs;
+} threadArgs;
 
 int AwaitDGram(WOLFSSL_CTX* ctx)
 {
@@ -137,7 +137,8 @@ int AwaitDGram(WOLFSSL_CTX* ctx)
                 return 1;
             }
                 #ifdef SO_REUSEPORT
-                    res = setsockopt(args->activefd, SOL_SOCKET, SO_REUSEPORT, &on, len);
+                    res = setsockopt(args->activefd, SOL_SOCKET,
+                                        SO_REUSEPORT, &on, len);
                     if (res < 0) {
                         printf("Setsockopt SO_REUSEPORT failed.\n");
                         cleanup = 1;
@@ -218,7 +219,7 @@ void* ThreadControl(void* openSock)
         printf("wolfSSL_write fail.\n");
         cleanup = 1;
         return NULL;
-    } 
+    }
     else {
         printf("Sending reply.\n");
     }

--- a/dtls/server-dtls.c
+++ b/dtls/server-dtls.c
@@ -1,4 +1,4 @@
-/* server-dtls.c 
+/* server-dtls.c
  *
  * Copyright (C) 2006-2015 wolfSSL Inc.
  *
@@ -24,6 +24,7 @@
  * Utilizes DTLS 1.2.
  */
 
+#include <wolfssl/options.h>
 #include <stdio.h>                  /* standard in/out procedures */
 #include <stdlib.h>                 /* defines system calls */
 #include <string.h>                 /* necessary for memset */
@@ -49,8 +50,8 @@ void CleanUp();
 int AwaitDGram(WOLFSSL_CTX* ctx)
 {
     int           on = 1;
-    int           res = 1; 
-    int           connfd = 0;  
+    int           res = 1;
+    int           connfd = 0;
     int           recvLen = 0;    /* length of message */
     int           listenfd = 0;   /* Initialize our socket */
     WOLFSSL*       ssl = NULL;
@@ -86,7 +87,7 @@ int AwaitDGram(WOLFSSL_CTX* ctx)
         }
 
         /*Bind Socket*/
-        if (bind(listenfd, 
+        if (bind(listenfd,
                     (struct sockaddr *)&servAddr, sizeof(servAddr)) < 0) {
             printf("Bind failed.\n");
             cleanup = 1;
@@ -95,7 +96,7 @@ int AwaitDGram(WOLFSSL_CTX* ctx)
 
         printf("Awaiting client connection on port %d\n", SERV_PORT);
 
-        cliLen = sizeof(cliaddr);   
+        cliLen = sizeof(cliaddr);
         connfd = (int)recvfrom(listenfd, (char *)&b, sizeof(b), MSG_PEEK,
                 (struct sockaddr*)&cliaddr, &cliLen);
 
@@ -104,7 +105,7 @@ int AwaitDGram(WOLFSSL_CTX* ctx)
             continue;
         }
         else if (connfd > 0) {
-            if (connect(listenfd, (const struct sockaddr *)&cliaddr, 
+            if (connect(listenfd, (const struct sockaddr *)&cliaddr,
                         sizeof(cliaddr)) != 0) {
                 printf("Udp connect failed.\n");
                 cleanup = 1;
@@ -124,10 +125,10 @@ int AwaitDGram(WOLFSSL_CTX* ctx)
             cleanup = 1;
             return 1;
         }
-        
+
         /* set the session ssl to client connection port */
         wolfSSL_set_fd(ssl, listenfd);
-        
+
         if (wolfSSL_accept(ssl) != SSL_SUCCESS) {
 
             int e = wolfSSL_get_error(ssl, 0);
@@ -154,15 +155,15 @@ int AwaitDGram(WOLFSSL_CTX* ctx)
             printf("wolfSSL_write fail.\n");
             cleanup = 1;
             return 1;
-        } 
+        }
         else {
             printf("Sending reply.\n");
         }
 
         printf("reply sent \"%s\"\n", ack);
 
-        wolfSSL_set_fd(ssl, 0); 
-        wolfSSL_shutdown(ssl);        
+        wolfSSL_set_fd(ssl, 0);
+        wolfSSL_shutdown(ssl);
         wolfSSL_free(ssl);
 
         printf("Client left return to idle state\n");
@@ -172,13 +173,13 @@ int AwaitDGram(WOLFSSL_CTX* ctx)
 
 int main(int argc, char** argv)
 {
-    /* cont short for "continue?", Loc short for "location" */    
+    /* cont short for "continue?", Loc short for "location" */
     int         cont = 0;
     char        caCertLoc[] = "../certs/ca-cert.pem";
     char        servCertLoc[] = "../certs/server-cert.pem";
     char        servKeyLoc[] = "../certs/server-key.pem";
     WOLFSSL_CTX* ctx;
-    
+
     /* "./config --enable-debug" and uncomment next line for debugging */
     /* wolfSSL_Debugging_ON(); */
 
@@ -191,7 +192,7 @@ int main(int argc, char** argv)
         return 1;
     }
     /* Load CA certificates */
-    if (wolfSSL_CTX_load_verify_locations(ctx,caCertLoc,0) != 
+    if (wolfSSL_CTX_load_verify_locations(ctx,caCertLoc,0) !=
             SSL_SUCCESS) {
         printf("Error loading %s, please check the file.\n", caCertLoc);
         return 1;
@@ -203,7 +204,7 @@ int main(int argc, char** argv)
         return 1;
     }
     /* Load server Keys */
-    if (wolfSSL_CTX_use_PrivateKey_file(ctx, servKeyLoc, 
+    if (wolfSSL_CTX_use_PrivateKey_file(ctx, servKeyLoc,
                 SSL_FILETYPE_PEM) != SSL_SUCCESS) {
         printf("Error loading %s, please check the file.\n", servKeyLoc);
         return 1;

--- a/dtls/server-udp.c
+++ b/dtls/server-udp.c
@@ -1,5 +1,5 @@
-/* 
- * server-udp.c 
+/*
+ * server-udp.c
  *
  * Copyright (C) 2006-2015 wolfSSL Inc.
  *
@@ -35,7 +35,7 @@
 #define SERV_PORT   11111                   /* define our server port number */
 #define MSGLEN      4096                    /* limit incoming message size */
 
-int main (int argc, char** argv) 
+int main (int argc, char** argv)
 {
     int           sockfd;                   /* Initialize our socket */
     int           recvLen;                  /* number of bytes recieved */
@@ -69,7 +69,7 @@ int main (int argc, char** argv)
         memset(buf, 0, sizeof(buf));
         printf("waiting for client message on port %d\n", SERV_PORT);
 
-        recvLen = recvfrom(sockfd, buf, MSGLEN, 0, 
+        recvLen = recvfrom(sockfd, buf, MSGLEN, 0,
                 (struct sockaddr *)&cliAddr, &cliAddrLen);
 
         printf("heard %d bytes\n", recvLen);
@@ -84,7 +84,7 @@ int main (int argc, char** argv)
         printf("Message #%d received\n", msgNum++);
         printf("reply sent \"%s\"\n", buf);
 
-        if (sendto(sockfd, buf, sizeof(buf), 0, 
+        if (sendto(sockfd, buf, sizeof(buf), 0,
                     (struct sockaddr *)&cliAddr, cliAddrLen) < 0) {
             printf("\"sendto\" failed.\n");
             return 1;


### PR DESCRIPTION
- Removed unnecessary whitespaces in DTLS examples folder
- Fixed a memset warning where two parameters were in the wrong order
- Fixed recurring RNG memory leak in crypto example library