### PR TITLE
Fix Btle example spelling errors and Makefile to use dynamic library

### DIFF
--- a/btle/Makefile
+++ b/btle/Makefile
@@ -39,3 +39,5 @@ ecc-client: ecc-client.o btle-sim.o $(STATIC_LIB)
 
 clean:
 	rm *.o
+	rm ecc-server
+	rm ecc-client

--- a/btle/Makefile
+++ b/btle/Makefile
@@ -6,15 +6,17 @@ LIBS     = -L$(LIB_PATH)/lib
 
 # option variables
 DYN_LIB         = -lwolfssl
-STATIC_LIB      = $(LIB_PATH)/lib/libwolfssl.a
+STATIC_LIB      =
 DEBUG_FLAGS     = -g -DDEBUG
 OPTIMIZE        = -Os
 
 # Options
-CFLAGS+=$(DEBUG_FLAGS)
+#CFLAGS+=$(DEBUG_FLAGS)
 #CFLAGS+=$(OPTIMIZE)
 
-#LIBS+=$(DYN_LIB) -lm
+# Static or Dynamic Library
+#STATIC_LIB+=$(LIB_PATH)/lib/libwolfssl.a
+LIBS+=$(DYN_LIB) -lm
 
 
 .PHONY: clean all

--- a/btle/Makefile
+++ b/btle/Makefile
@@ -7,7 +7,7 @@ LIBS     = -L$(LIB_PATH)/lib
 # option variables
 DYN_LIB         = -lwolfssl
 STATIC_LIB      =
-DEBUG_FLAGS     = -g -DDEBUG
+DEBUG_FLAGS     = -g -DDEBUG -DDEBUG_WOLFSSL
 OPTIMIZE        = -Os
 
 # Options

--- a/btle/README.md
+++ b/btle/README.md
@@ -1,28 +1,38 @@
 # BTLE Examples
 
-Bluetooth Low Energy (BTLE or BLE) is a leightweight / low power wireless protocol. Its supported by Apple iPhone 4s and later and most Android phones. It operates in the 2.4GHz spectrum and has 3 advertising channels and 37 data channels.
+BTLE / Lightweight Secure Transport Example:
 
-These examples demonstrate leightweight methods for exchanging data securley over anytype of publically visible link.
+Bluetooth Low Energy (BTLE) is a lightweight / low power wireless protocol. Its supported by Apple iPhone 4s and later and most Android phones. It operates in the 2.4GHz spectrum and has 3 advertising channels and 37 data channels.
 
-The first phase is key establishment, which is done through ECDH and HDKF. ECC was choosen for these examples because its leightweight and widely used. Salt exchanged to provent data reply of messages. The enryption is done with AES CBC. The data integrity is done using HMAC-SHA256.
+This example demonstrates a lightweight method for exchanging data securely over any type of publicly visible link.
+
+The first phase is key establishment, which is done through ECDH and HDKF. ECC was chosen for these examples because its lightweight and widely used. Then salt exchanged for each message to prevent reply attacks. The encryption is done with AES CBC. The data integrity is done using HMAC-SHA256.
+
 
 ## ECC Encrypt/Decrypt Example
 
 See `BTLESecureMessageExchange.pdf` for details.
 
+
 ### Building
 
 The wolfSSL library must be built and installed using './configure --enable-ecc --enable-eccencrypt --enable-hkdf && make && sudo make install' or by defining `#define HAVE_ECC`, `#define HAVE_ECC_ENCRYPT` and `HAVE_HKDF`.
 
+
 ### Usage
 
-Use two consoles and STDIN to exchange data between the client and server.
+Use two consoles and STDIN to exchange data between the client and server. From the client enter a message and hit enter. This will be encrypted and sent to the server. The server will decrypt, print and re-encrypt the message and send it back to the client (echo).
 
 ```
 ./ecc-server
 ./ecc-client
 ```
 
-### BTLE Simulator
+### Debugging
 
-The simulator uses IPC (pipes) to communicate between threads for simualted communication between two devices.
+To enable debugging or switch to using a static version of wolfSSL edit the `Makefile` and uncomment `CFLAGS+=$(DEBUG_FLAGS)` and `STATIC_LIB+=$(LIB_PATH)/lib/libwolfssl.a`. Then comment out `LIBS+=$(DYN_LIB) -lm`.
+
+
+## BTLE Simulator
+
+The simulator uses IPC (pipes) to communicate between threads for simulated communication between two devices.


### PR DESCRIPTION
Fixed several typos in `btle/README.md`. Changed the `btle/Makefile` to default to non-debug / dynamic wolfSSL library.