### PR TITLE
Update wolfssl-examples to properly include options.h

### DIFF
--- a/tls/client-tls-callback.c
+++ b/tls/client-tls-callback.c
@@ -32,6 +32,7 @@
 #include <unistd.h>
 
 /* wolfSSL */
+#include <wolfssl/options.h>
 #include <wolfssl/ssl.h>
 
 #define DEFAULT_PORT 11111

--- a/tls/client-tls-ecdhe.c
+++ b/tls/client-tls-ecdhe.c
@@ -31,6 +31,7 @@
 #include <unistd.h>
 
 /* wolfSSL */
+#include <wolfssl/options.h>
 #include <wolfssl/ssl.h>
 
 #define DEFAULT_PORT 11111

--- a/tls/client-tls-nonblocking.c
+++ b/tls/client-tls-nonblocking.c
@@ -31,6 +31,7 @@
 #include <unistd.h>
 
 /* wolfSSL */
+#include <wolfssl/options.h>
 #include <wolfssl/ssl.h>
 
 #define DEFAULT_PORT 11111

--- a/tls/client-tls-resume.c
+++ b/tls/client-tls-resume.c
@@ -31,6 +31,7 @@
 #include <unistd.h>
 
 /* wolfSSL */
+#include <wolfssl/options.h>
 #include <wolfssl/ssl.h>
 
 #define DEFAULT_PORT 11111

--- a/tls/client-tls-writedup.c
+++ b/tls/client-tls-writedup.c
@@ -35,8 +35,8 @@
 #include <unistd.h>
 
 /* wolfSSL */
-#include <wolfssl/ssl.h>
 #include <wolfssl/options.h>
+#include <wolfssl/ssl.h>
 
 /* check for writedup */
 #ifndef HAVE_WRITE_DUP

--- a/tls/client-tls.c
+++ b/tls/client-tls.c
@@ -31,6 +31,7 @@
 #include <unistd.h>
 
 /* wolfSSL */
+#include <wolfssl/options.h>
 #include <wolfssl/ssl.h>
 
 #define DEFAULT_PORT 11111

--- a/tls/server-tls-callback.c
+++ b/tls/server-tls-callback.c
@@ -32,6 +32,7 @@
 #include <unistd.h>
 
 /* wolfSSL */
+#include <wolfssl/options.h>
 #include <wolfssl/ssl.h>
 
 #define DEFAULT_PORT 11111

--- a/tls/server-tls-ecdhe.c
+++ b/tls/server-tls-ecdhe.c
@@ -31,6 +31,7 @@
 #include <unistd.h>
 
 /* wolfSSL */
+#include <wolfssl/options.h>
 #include <wolfssl/ssl.h>
 
 #define DEFAULT_PORT 11111

--- a/tls/server-tls-nonblocking.c
+++ b/tls/server-tls-nonblocking.c
@@ -32,6 +32,7 @@
 #include <unistd.h>
 
 /* wolfSSL */
+#include <wolfssl/options.h>
 #include <wolfssl/ssl.h>
 
 #define DEFAULT_PORT 11111

--- a/tls/server-tls-threaded.c
+++ b/tls/server-tls-threaded.c
@@ -31,6 +31,7 @@
 #include <unistd.h>
 
 /* wolfSSL */
+#include <wolfssl/options.h>
 #include <wolfssl/ssl.h>
 
 /* threads */

--- a/tls/server-tls.c
+++ b/tls/server-tls.c
@@ -31,6 +31,7 @@
 #include <unistd.h>
 
 /* wolfSSL */
+#include <wolfssl/options.h>
 #include <wolfssl/ssl.h>
 
 #define DEFAULT_PORT 11111


### PR DESCRIPTION
wolfssl-examples will no longer build out-of-the box with the sanity check for harden in <wolfssl-root>/wolfssl/wolfcrypt/settings.h unless the options.h header is properly included to match the library configuration. (Alternate solution would be to update the Makefile however this is the best solution to ENSURE configuration matches the library and will still allow for the warning to be thrown in the event the library was configured with --disable-harden)