### PR TITLE
include main header for options.h prior to other wolfSSL headers

### DIFF
--- a/wolfCLU/clu_src/x509/clu_cert_setup.c
+++ b/wolfCLU/clu_src/x509/clu_cert_setup.c
@@ -21,8 +21,8 @@
 
 #include <stdio.h>
 #include <unistd.h>
-#include <wolfssl/wolfcrypt/types.h>
 #include "clu_include/clu_header_main.h"
+#include <wolfssl/wolfcrypt/types.h>
 #include "clu_include/clu_error_codes.h"
 #include "clu_include/x509/clu_cert.h"
 #include "clu_include/x509/clu_parse.h"

--- a/wolfCLU/clu_src/x509/clu_parse.c
+++ b/wolfCLU/clu_src/x509/clu_parse.c
@@ -20,9 +20,9 @@
  */
 
 #include <stdio.h>
+#include "clu_include/clu_header_main.h"
 #include <wolfssl/wolfcrypt/asn_public.h>
 #include <wolfssl/ssl.h> /* wolfSSL_CertPemToDer */
-#include "clu_include/clu_header_main.h"
 #include "clu_include/clu_error_codes.h"
 #include "clu_include/x509/clu_parse.h"
 


### PR DESCRIPTION
options.h should be included before any other wolfSSL headers. By including the main wolfCLU header (which includes options.h) prior to other wolfSSL headers we accomplish this.