### PR TITLE
Deflagify

### DIFF
--- a/wolfCLU/clu_include/clu_header_main.h
+++ b/wolfCLU/clu_include/clu_header_main.h
@@ -94,23 +94,26 @@
  *
  * @param argc holds all command line input
  * @param argv each holds one value from the command line input
+ * @param offset offset to where the non-flag arguments start
  * @param action forwarded from wolfCLU_main (-e, -d, -h, or -b)
  */
-int wolfCLU_setup(int argc, char** argv, char action);
+int wolfCLU_setup(int argc, char** argv, int offset, char action);
 
 /* hash argument function
  *
  * @param argc holds all command line input
  * @param argv each holds one value from the command line input
+ * @param offset offset to where the non-flag arguments start
  */
-int wolfCLU_hashSetup(int argc, char** argv);
+int wolfCLU_hashSetup(int argc, char** argv, int offset);
 
 /* benchmark argument function
  *
  * @param argc holds all command line input
  * @param argv each holds one value from the command line input
+ * @param offset offset to where the non-flag arguments start
  */
-int wolfCLU_benchSetup(int argc, char** argv);
+int wolfCLU_benchSetup(int argc, char** argv, int offset);
 
 /*
  * generic help function

--- a/wolfCLU/clu_include/clu_optargs.h
+++ b/wolfCLU/clu_include/clu_optargs.h
@@ -22,15 +22,6 @@
 
 /* Enumerated types for long arguments */
 enum {
-    /* @temporary: implement modes as arguments */
-    ENCRYPT = 1000,
-    DECRYPT,
-    BENCHMARK,
-    HASH,
-    X509,
-    REQUEST,
-    GEN_KEY,
-
     INFILE,
     OUTFILE,
     PASSWORD,
@@ -53,16 +44,6 @@ enum {
 
 /* Structure for holding long arguments */
 static struct option long_options[] = {
-
-    /* @temporary: implement modes as flags */
-    {"encrypt", required_argument, 0, ENCRYPT   },
-    {"decrypt", required_argument, 0, DECRYPT   },
-    {"bench",   no_argument,       0, BENCHMARK },
-    {"hash",    required_argument, 0, HASH      },
-    {"x509",    no_argument,       0, X509      },
-    {"req",     required_argument, 0, REQUEST   },
-    {"genkey",  required_argument, 0, GEN_KEY   },
-
     {"in",      required_argument, 0, INFILE    },
     {"out",     required_argument, 0, OUTFILE   },
     {"pwd",     required_argument, 0, PASSWORD  },

--- a/wolfCLU/clu_include/genkey/clu_genkey.h
+++ b/wolfCLU/clu_include/genkey/clu_genkey.h
@@ -42,7 +42,7 @@ enum {
 };
 
 /* handles incoming arguments for certificate generation */
-int wolfCLU_genKeySetup(int argc, char** argv);
+int wolfCLU_genKeySetup(int argc, char** argv, int offset);
 
 #ifdef HAVE_ED25519
 /* Generate an ED25519 key */

--- a/wolfCLU/clu_include/x509/clu_cert.h
+++ b/wolfCLU/clu_include/x509/clu_cert.h
@@ -28,7 +28,7 @@ enum {
 };
 
 /* handles incoming arguments for certificate generation */
-int wolfCLU_certSetup(int argc, char** argv);
+int wolfCLU_certSetup(int argc, char** argv, int offset);
 
 /* print help info */
 void wolfCLU_certHelp();

--- a/wolfCLU/clu_include/x509/clu_request.h
+++ b/wolfCLU/clu_include/x509/clu_request.h
@@ -20,6 +20,6 @@
  */
 
 /* handles incoming arguments for certificate requests */
-int wolfCLU_requestSetup(int argc, char** argv);
+int wolfCLU_requestSetup(int argc, char** argv, int offset);
 
 

--- a/wolfCLU/clu_src/benchmark/clu_bench_setup.c
+++ b/wolfCLU/clu_src/benchmark/clu_bench_setup.c
@@ -21,7 +21,7 @@
 
 #include "clu_include/clu_header_main.h"
 
-int wolfCLU_benchSetup(int argc, char** argv)
+int wolfCLU_benchSetup(int argc, char** argv, int offset)
 {
     int     ret     =   0;          /* return variable */
     int     time    =   3;          /* timer variable */
@@ -95,10 +95,11 @@ int wolfCLU_benchSetup(int argc, char** argv)
 
     /* pull as many of the algorithms out of the argv as posible */
     for (i = 0; i < (int)algsSz; ++i) {
-        ret = wolfCLU_checkForArg(algs[i], XSTRLEN(algs[i]), argc, argv);
-        if (ret > 0) {
-            option[i] = 1;
-            optionCheck = 1;
+        for (j = offset; j > argc; ++j) {
+            if (XSTRNCMP(argv[j], algs[i], XSTRLEN(algs[i]))) {
+                option[i] = 1;
+                optionCheck = 1;
+            }
         }
     }
 

--- a/wolfCLU/clu_src/clu_main.c
+++ b/wolfCLU/clu_src/clu_main.c
@@ -31,8 +31,7 @@
 
 int main(int argc, char** argv)
 {
-    int     flag = 0;
-    char*   mode = "";
+    int     helpCheck = 0;
     int     ret = 0;
     int     option = 0;
     int     ignoreIn = 0;
@@ -49,17 +48,6 @@ int main(int argc, char** argv)
                    long_options, &long_index )) != -1) {
 
         switch (option) {
-
-            /* @temporary: implement the modes as arguments */
-        case ENCRYPT:
-        case DECRYPT:
-        case BENCHMARK:
-        case HASH:
-        case X509:
-        case REQUEST:
-        case GEN_KEY:
-
-            if (!flag) flag = option;
 
             /*
              * Ignore the following arguments for now. They will be handled by
@@ -98,12 +86,7 @@ int main(int argc, char** argv)
              */
 
         case HELP:
-            /* only print for -help if no mode has been declared */
-            if (!flag) {
-                printf("Main help menu:\n");
-                wolfCLU_help();
-                return 0;
-            }
+            helpCheck = 1;
             break;
 
         case VERBOSE:
@@ -122,39 +105,34 @@ int main(int argc, char** argv)
     }
 
     /* @temporary: implement mode as a flag */
-    switch (flag) {
-    case 0:
-        printf("No mode provided.\n");
-        ret = 0;
-        break;
-
-    case ENCRYPT:
-        ret = wolfCLU_setup(argc, argv, 'e');
-        break;
-
-    case DECRYPT:
-        ret = wolfCLU_setup(argc, argv, 'd');
-        break;
-
-    case BENCHMARK:
-        ret = wolfCLU_benchSetup(argc, argv);
-        break;
-
-    case HASH:
-        ret = wolfCLU_hashSetup(argc, argv);
-        break;
-
-    case X509:
-        ret = wolfCLU_certSetup(argc, argv);
-        break;
-
-    case REQUEST:
-        ret = wolfCLU_requestSetup(argc, argv);
-        break;
-
-    case GEN_KEY:
-        ret = wolfCLU_genKeySetup(argc, argv);
-        break;
+    /* @temporary: implement modes as flags */
+    if (XSTRNCMP(argv[optind], "encrypt", 7) == 0) {
+        ret = wolfCLU_setup(argc, argv, optind, 'e');
+    }
+    else if (XSTRNCMP(argv[optind], "decrypt", 7) == 0) {
+        ret = wolfCLU_setup(argc, argv, optind, 'd');
+    }
+    else if (XSTRNCMP(argv[optind], "bench", 5) == 0) {
+        ret = wolfCLU_benchSetup(argc, argv, optind);
+    }
+    else if (XSTRNCMP(argv[optind], "hash", 4) == 0) {
+        ret = wolfCLU_hashSetup(argc, argv, optind);
+    }
+    else if (XSTRNCMP(argv[optind], "x509", 4) == 0) {
+        ret = wolfCLU_certSetup(argc, argv, optind);
+    }
+    else if (XSTRNCMP(argv[optind], "req", 3) == 0) {
+        ret = wolfCLU_requestSetup(argc, argv, optind);
+    }
+    else if (XSTRNCMP(argv[optind], "genkey", 6) == 0) {
+        ret = wolfCLU_genKeySetup(argc, argv, optind);
+    }
+    else if (helpCheck == 1) {
+        wolfCLU_help();
+    }
+    else {
+        printf("%s: '%s' is not a valid mode. Please consult -help\n",
+               argv[0], argv[optind]);
     }
 
     if (ret != 0)

--- a/wolfCLU/clu_src/clu_main.c
+++ b/wolfCLU/clu_src/clu_main.c
@@ -104,9 +104,14 @@ int main(int argc, char** argv)
         }
     }
 
-    /* @temporary: implement mode as a flag */
-    /* @temporary: implement modes as flags */
-    if (XSTRNCMP(argv[optind], "encrypt", 7) == 0) {
+    /* look for modes */
+
+    if (argv[optind] == NULL) {
+        if (helpCheck == 1) {
+            wolfCLU_help();
+        }
+    }
+    else if (XSTRNCMP(argv[optind], "encrypt", 7) == 0) {
         ret = wolfCLU_setup(argc, argv, optind, 'e');
     }
     else if (XSTRNCMP(argv[optind], "decrypt", 7) == 0) {
@@ -126,9 +131,6 @@ int main(int argc, char** argv)
     }
     else if (XSTRNCMP(argv[optind], "genkey", 6) == 0) {
         ret = wolfCLU_genKeySetup(argc, argv, optind);
-    }
-    else if (helpCheck == 1) {
-        wolfCLU_help();
     }
     else {
         printf("%s: '%s' is not a valid mode. Please consult -help\n",

--- a/wolfCLU/clu_src/crypto/clu_crypto_setup.c
+++ b/wolfCLU/clu_src/crypto/clu_crypto_setup.c
@@ -21,7 +21,7 @@
 
 #include "clu_include/clu_header_main.h"
 
-int wolfCLU_setup(int argc, char** argv, char action)
+int wolfCLU_setup(int argc, char** argv, int offset, char action)
 {
     char     outNameE[256];     /* default outFile for encrypt */
     char     outNameD[256];     /* default outfile for decrypt */
@@ -71,7 +71,7 @@ int wolfCLU_setup(int argc, char** argv, char action)
         }
     }
 
-    name = argv[2];
+    name = argv[offset + 1];
     if (name == NULL) {
         return FATAL_ERROR;
     }

--- a/wolfCLU/clu_src/genkey/clu_genkey_setup.c
+++ b/wolfCLU/clu_src/genkey/clu_genkey_setup.c
@@ -47,6 +47,10 @@ int wolfCLU_genKeySetup(int argc, char** argv, int offset)
     XMEMSET(keyOutFName, 0, MAX_FILENAME_SZ);
 
     keyType = argv[offset+1];
+    if (keyType == NULL) {
+        printf("No key type provided.\n");
+        return USER_INPUT_ERROR;
+    }
 
     ret = wc_InitRng(&rng);
 

--- a/wolfCLU/clu_src/genkey/clu_genkey_setup.c
+++ b/wolfCLU/clu_src/genkey/clu_genkey_setup.c
@@ -23,7 +23,7 @@
 #include "clu_include/genkey/clu_genkey.h"
 #include "clu_include/x509/clu_cert.h"  /* argument checking */
 
-int wolfCLU_genKeySetup(int argc, char** argv)
+int wolfCLU_genKeySetup(int argc, char** argv, int offset)
 {
     char     keyOutFName[MAX_FILENAME_SZ];  /* default outFile for genKey */
     char     defaultFormat[4] = "der\0";
@@ -46,7 +46,7 @@ int wolfCLU_genKeySetup(int argc, char** argv)
 
     XMEMSET(keyOutFName, 0, MAX_FILENAME_SZ);
 
-    keyType = argv[2];
+    keyType = argv[offset+1];
 
     ret = wc_InitRng(&rng);
 

--- a/wolfCLU/clu_src/hash/clu_hash_setup.c
+++ b/wolfCLU/clu_src/hash/clu_hash_setup.c
@@ -24,7 +24,7 @@
 /*
  * hash argument function
  */
-int wolfCLU_hashSetup(int argc, char** argv)
+int wolfCLU_hashSetup(int argc, char** argv, int offset)
 {
     int     ret        =   0;   /* return variable, counter */
     int     i          =   0;   /* loop variable */
@@ -50,9 +50,9 @@ int wolfCLU_hashSetup(int argc, char** argv)
         "blake2b",
 #endif
 #ifndef NO_CODING
-    #ifdef WOLFSSL_BASE64_ENCODE
+#ifdef WOLFSSL_BASE64_ENCODE
         "base64enc",
-    #endif
+#endif
         "base64dec",
 #endif
         NULL /* terminal element (also stops the array from being 0-size */
@@ -77,8 +77,8 @@ int wolfCLU_hashSetup(int argc, char** argv)
 
     for (i = 0; i < (int)algsSz; ++i) {
         /* checks for acceptable algorithms */
-        if (XSTRNCMP(argv[2], algs[i], XSTRLEN(algs[i])) == 0) {
-            alg = argv[2];
+        if (XSTRNCMP(argv[offset+1], algs[i], XSTRLEN(algs[i])) == 0) {
+            alg = argv[offset+1];
             algCheck = 1;
         }
     }

--- a/wolfCLU/clu_src/hash/clu_hash_setup.c
+++ b/wolfCLU/clu_src/hash/clu_hash_setup.c
@@ -75,7 +75,11 @@ int wolfCLU_hashSetup(int argc, char** argv, int offset)
         return 0;
     }
 
-    for (i = 0; i < (int)algsSz; ++i) {
+    if (argv[offset+1] == NULL) {
+        printf("No algorithm provided\n");
+        return FATAL_ERROR;
+    }
+    else for (i = 0; i < (int)algsSz; ++i) {
         /* checks for acceptable algorithms */
         if (XSTRNCMP(argv[offset+1], algs[i], XSTRLEN(algs[i])) == 0) {
             alg = argv[offset+1];

--- a/wolfCLU/clu_src/tools/clu_funcs.c
+++ b/wolfCLU/clu_src/tools/clu_funcs.c
@@ -39,11 +39,12 @@ int     i          =   0;       /* loop variable */
     printf("-help           Help, print out this help menu\n");
     printf("\n");
     printf("Only set one of the following.\n\n");
-    printf("-encrypt        Encrypt a file or some user input\n");
-    printf("-decrypt        Decrypt an encrypted file\n");
-    printf("-hash           Hash a file or input\n");
-    printf("-bench          Benchmark one of the algorithms\n");
-    printf("-x509           X509 certificate processing\n");
+    printf("encrypt         Encrypt a file or some user input\n");
+    printf("decrypt         Decrypt an encrypted file\n");
+    printf("hash            Hash a file or input\n");
+    printf("bench           Benchmark one of the algorithms\n");
+    printf("x509            X509 certificate processing\n");
+    printf("genkey          Generate a key\n");
     printf("\n");
     /*optional flags*/
     printf("Optional Flags.\n\n");
@@ -59,15 +60,15 @@ int     i          =   0;       /* loop variable */
     printf("-verbose        display a more verbose help menu\n");
     printf("-inform         input format of the certificate file [PEM/DER]\n");
     printf("-outform        format to output [PEM/DER]\n");
-    printf("-output         used with -genkey option to specify which keys to\n"
+    printf("-output         used with genkey option to specify which keys to\n"
            "                output [PUB/PRIV/KEYPAIR]\n");
-
-    printf("\nFor encryption:   wolfssl -encrypt -help\n");
-    printf("For decryption:   wolfssl -decrypt -help\n");
-    printf("For hashing:      wolfssl -hash -help\n");
-    printf("For benchmarking: wolfssl -bench -help\n");
-    printf("For x509:         wolfssl -x509 -help\n");
-    printf("For key creation: wolfssl -genkey -help\n\n");
+    printf("\n");
+    printf("For encryption:   wolfssl encrypt -help\n");
+    printf("For decryption:   wolfssl decrypt -help\n");
+    printf("For hashing:      wolfssl hash -help\n");
+    printf("For benchmarking: wolfssl bench -help\n");
+    printf("For x509:         wolfssl x509 -help\n");
+    printf("For key creation: wolfssl genkey -help\n\n");
  }
 
 /*
@@ -191,10 +192,10 @@ void wolfCLU_encryptHelp()
             "camellia-cbc-256\n\n");
 #endif
     printf("***************************************************************\n");
-    printf("\nENCRYPT USAGE: wolfssl -encrypt <-algorithm> -in <filename> "
+    printf("\nENCRYPT USAGE: wolfssl encrypt <-algorithm> -in <filename> "
            "-pwd <password> -out <output file name>\n\n");
     printf("***************************************************************\n");
-    printf("\nEXAMPLE: \n\nwolfssl -encrypt aes-cbc-128 -pwd Thi$i$myPa$$w0rd"
+    printf("\nEXAMPLE: \n\nwolfssl encrypt aes-cbc-128 -pwd Thi$i$myPa$$w0rd"
            " -in somefile.txt -out encryptedfile.txt\n\n");
 }
 
@@ -219,10 +220,10 @@ void wolfCLU_decryptHelp()
             "camellia-cbc-256\n\n");
 #endif
     printf("***************************************************************\n");
-    printf("\nDECRYPT USAGE: wolfssl -decrypt <algorithm> -in <encrypted file> "
+    printf("\nDECRYPT USAGE: wolfssl decrypt <algorithm> -in <encrypted file> "
            "-pwd <password> -out <output file name>\n\n");
     printf("***************************************************************\n");
-    printf("\nEXAMPLE: \n\nwolfssl -decrypt aes-cbc-128 -pwd Thi$i$myPa$$w0rd"
+    printf("\nEXAMPLE: \n\nwolfssl decrypt aes-cbc-128 -pwd Thi$i$myPa$$w0rd"
            " -in encryptedfile.txt -out decryptedfile.txt\n\n");
 }
 
@@ -266,9 +267,9 @@ void wolfCLU_hashHelp()
     }
             /* encryption/decryption help lists options */
     printf("***************************************************************\n");
-    printf("\nUSAGE: wolfssl -hash <-algorithm> -in <file to hash>\n");
+    printf("\nUSAGE: wolfssl hash <-algorithm> -in <file to hash>\n");
     printf("***************************************************************\n");
-    printf("\nEXAMPLE: \n\nwolfssl -hash sha -in <some file>\n\n");
+    printf("\nEXAMPLE: \n\nwolfssl hash sha -in <some file>\n\n");
 }
 
 /*
@@ -320,10 +321,10 @@ void wolfCLU_benchHelp()
     printf("\n");
             /* encryption/decryption help lists options */
     printf("***************************************************************\n");
-    printf("USAGE: wolfssl -bench [alg] -time [time in seconds [1-10]]\n"
-           "       or\n       wolfssl -bench -time 10 -all (to test all)\n");
+    printf("USAGE: wolfssl bench [alg] -time [time in seconds [1-10]]\n"
+           "       or\n       wolfssl bench -time 10 -all (to test all)\n");
     printf("***************************************************************\n");
-    printf("\nEXAMPLE: \n\nwolfssl -bench aes-cbc -time 10"
+    printf("\nEXAMPLE: \n\nwolfssl bench aes-cbc -time 10"
            " -in encryptedfile.txt -out decryptedfile.txt\n\n");
 }
 
@@ -331,10 +332,10 @@ void wolfCLU_certHelp()
 {
     printf("\n\n");
     printf("***************************************************************\n");
-    printf("\nX509 USAGE: wolfssl -x509 -inform <PEM or DER> -in <filename> "
+    printf("\nX509 USAGE: wolfssl x509 -inform <PEM or DER> -in <filename> "
            "-outform <PEM or DER> -out <output file name> \n\n");
     printf("***************************************************************\n");
-    printf("\nEXAMPLE: \n\nwolfssl -x509 -inform pem -in testing-certs/"
+    printf("\nEXAMPLE: \n\nwolfssl x509 -inform pem -in testing-certs/"
            "ca-cert.pem -outform der -out testing-certs/ca-cert-converted.der"
            "\n\n");
 }
@@ -342,10 +343,10 @@ void wolfCLU_certHelp()
 void wolfCLU_genKeyHelp() {
     printf("\n\n");
     printf("***************************************************************\n");
-    printf("\ngenkey USAGE:\nwolfssl -genkey <keytype> -out <filename> -outform"
+    printf("\ngenkey USAGE:\nwolfssl genkey <keytype> -out <filename> -outform"
            " <PEM or DER> -output <PUB/PRIV/KEYPAIR> \n\n");
     printf("***************************************************************\n");
-    printf("\nEXAMPLE: \n\nwolfssl -genkey ed25519 -out mykey -outform der "
+    printf("\nEXAMPLE: \n\nwolfssl genkey ed25519 -out mykey -outform der "
            " -output KEYPAIR"
            "\n\nThe above command would output the files: mykey.priv "
            " and mykey.pub\nChanging the -output option to just PRIV would only"

--- a/wolfCLU/clu_src/x509/clu_cert_setup.c
+++ b/wolfCLU/clu_src/x509/clu_cert_setup.c
@@ -35,7 +35,7 @@ enum {
     NOOUT_SET    = 5,
 };
 
-int wolfCLU_certSetup(int argc, char** argv)
+int wolfCLU_certSetup(int argc, char** argv, int offset)
 {
     int i, ret;
     int text_flag    = 0;   /* does user desire human readable cert info */

--- a/wolfCLU/clu_src/x509/clu_cert_setup.c
+++ b/wolfCLU/clu_src/x509/clu_cert_setup.c
@@ -53,6 +53,7 @@ int wolfCLU_certSetup(int argc, char** argv, int offset)
     char* inform;           /* the input format */
     char* outform;          /* the output format */
 
+    (void)offset;
 
 /*---------------------------------------------------------------------------*/
 /* help */

--- a/wolfCLU/clu_src/x509/clu_request_setup.c
+++ b/wolfCLU/clu_src/x509/clu_request_setup.c
@@ -23,6 +23,10 @@
 
 int wolfCLU_requestSetup(int argc, char** argv, int offset)
 {
+    (void)argc;
+    (void)argv;
+    (void)offset;
+
     return 0;
 }
 

--- a/wolfCLU/clu_src/x509/clu_request_setup.c
+++ b/wolfCLU/clu_src/x509/clu_request_setup.c
@@ -21,7 +21,7 @@
 
 #include "clu_include/x509/clu_request.h"
 
-int wolfCLU_requestSetup(int argc, char** argv)
+int wolfCLU_requestSetup(int argc, char** argv, int offset)
 {
     return 0;
 }

--- a/wolfCLU/tests/x509/x509-process-test.sh
+++ b/wolfCLU/tests/x509/x509-process-test.sh
@@ -13,15 +13,15 @@ test_return() {
 }
 
 test_case() {
-    echo "testing: ./wolfssl -x509 $1"
-    OUTPUT=$(./wolfssl -x509 $1)
+    echo "testing: ./wolfssl x509 $1"
+    OUTPUT=$(./wolfssl x509 $1)
     RESULT=$?
     test_return $RESULT "$OUTPUT"
 }
 
 cert_test_case() {
-    echo "testing: ./wolfssl -x509 $1"
-    OUTPUT=$(./wolfssl -x509 $1)
+    echo "testing: ./wolfssl x509 $1"
+    OUTPUT=$(./wolfssl x509 $1)
     RESULT=$?
     echo "RESULT: $RESULT"
     diff $2 $3


### PR DESCRIPTION
A branch un-implements the modes as flags (e.g., `-keygen` became `keygen`). The way it is done is to let the non-flag arguments float to the end of argv (thanks to getopt), use the first non-flag argument as the mode, and pass an offset integer to all of the setups. This offset tells the setup where that first non-flag argument is, which will always be the mode name (e.g., "keygen"). From there, where the setups previously looked for `argv[2]` they now look for `argv[offset+1]`.