### PR TITLE
Rsa sign-ver to achieve enc-dec example

### DIFF
--- a/signature/encryption-through-signing/README.md
+++ b/signature/encryption-through-signing/README.md
@@ -1,0 +1,73 @@
+An example that takes a simulated aes key (a string of 32-bytes / 256-bits)
+and encrypts it using RSA SSL Sign in wolfSSL. Keep in mind this is not a TRUE
+RSA ENCRYPT and will likely not inter-op with other libraries that offer a
+RSA_PRIVATE_ENCRYPT type API.
+
+This is a true SIGN operation.
+
+However this will achieve, for fixed-length inputs, an encrypt via sign of the
+input data.
+
+Then using a verify operation you can un-pad and recover the original input
+using the public key.
+
+This example was created as result of a question asked on our public forums here:
+https://www.wolfssl.com/forums/topic1117-does-wolfssl-support-using-rsa-private-key-to-encrypt-object-data.html
+
+
+------------------------
+
+BUILDING:
+
+configure wolfSSL library (https://wolfssl.com/download/)
+                          (https://github.com/wolfssl/wolfssl.git)
+with this option:
+
+```
+./configure CFLAGS="-DUSE_CERT_BUFFERS_2048"
+make
+sudo make install
+```
+
+Once the wolfSSL libraries are configured and installed the from this directory
+run the build.sh script which will generate the two applications
+
+rsa-priv-enc
+rsa-pub-dec
+
+------------------------
+
+USING:
+
+```
+./rsa-priv-enc
+```
+
+This will output the file "encryptedAesKey"
+which will contain the RSA "signed" (encrypted and padded) AES KEY that we
+specified on line 33 of the application "rsa-private-encrypt-app.c".
+
+```
+33     const byte in[] = "Thisismyfakeaeskeythatis32bytes!";
+```
+
+Now run
+
+```
+./rsa-pub-dec
+```
+
+This will open the file specified on line 32 of the application
+"rsa-public-decrypt-app.c" and "verify" (unpad and decrypt) the file using the
+public RSA key.
+
+```
+ 32     char fName[] = "encryptedAesKey";
+```
+
+-----------------------
+
+If you have any questions/concerns/feedback please contact wolfSSL at info@wolfssl.com
+or support@wolfssl.com anytime!
+
+

--- a/signature/encryption-through-signing/build.sh
+++ b/signature/encryption-through-signing/build.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+#NOTE: Set if using an alternate install location to /usr/local/lib for libwolfssl
+#Example:
+#CUSTOM_INCLUDE_DIR="/Users/<you>/wolf-install-dir-for-testing/include"
+#CUSTOM_LIB_DIR="/Users/<you>/wolf-install-dir-for-testing/lib"
+CUSTOM_INCLUDE_DIR=""
+CUSTOM_LIB_DIR=""
+
+
+gcc rsa-private-encrypt-app.c -o rsa-priv-enc \
+-I${CUSTOM_INCLUDE_DIR} \
+-L${CUSTOM_LIB_DIR} -lwolfssl
+
+gcc rsa-public-decrypt-app.c -o rsa-pub-dec \
+-I${CUSTOM_INCLUDE_DIR} \
+-L${CUSTOM_LIB_DIR} -lwolfssl
+

--- a/signature/encryption-through-signing/rsa-private-encrypt-app.c
+++ b/signature/encryption-through-signing/rsa-private-encrypt-app.c
@@ -1,0 +1,104 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+
+#include <wolfssl/options.h>
+#include <wolfssl/wolfcrypt/rsa.h>
+#include <wolfssl/ssl.h>
+/* certs_test.h contains der formatted key buffer rsa_key_der_2048 */
+#ifdef USE_CERT_BUFFERS_2048
+#include <wolfssl/certs_test.h>
+#else
+    #error "Please define USE_CERT_BUFFERS_2048 when building wolfSSL!"
+#endif
+
+void check_ret(int val, char* fail);
+
+#define RSA_TEST_BYTES 256 /* 256 bytes * 8 = 2048-bit key length */
+#define AES_KEY_SZ 32 /* 32*8 = 256-bit AES KEY */
+#define HEAP_HINT NULL
+
+int main(void)
+{
+    int    ret;
+    byte*  der = NULL;
+    byte*  pem = NULL;
+    size_t bytes;
+    WC_RNG rng;
+    RsaKey key;
+    word32 idx = 0;
+    byte*  res;
+    const word32 outSz   = RSA_TEST_BYTES;
+    const word32 plainSz = RSA_TEST_BYTES;
+    const byte in[] = "Thisismyfakeaeskeythatis32bytes!";
+    word32 inLen = XSTRLEN((const char*)in);
+
+    byte tmp[sizeof_client_key_der_2048];
+    byte out[RSA_TEST_BYTES];
+    byte plain[RSA_TEST_BYTES];
+
+    char fName[] = "encryptedAesKey";
+    FILE* fStream;
+
+    /* initialize stack structures */
+    XMEMSET(&rng, 0, sizeof(rng));
+    XMEMSET(&key, 0, sizeof(key));
+    XMEMSET(&out, 0, sizeof(out));
+    XMEMSET(&plain, 0, sizeof(plain));
+
+    bytes = (size_t)sizeof_client_key_der_2048;
+
+    /* Copy in existing Private RSA key into "tmp" to use for encrypting */
+    XMEMCPY(tmp, client_key_der_2048, (size_t)sizeof_client_key_der_2048);
+
+    /* Initialize the RSA key */
+    ret = wc_InitRsaKey(&key, HEAP_HINT);
+    check_ret(ret, "wc_InitRsaKey_ex");
+
+    /* Decode the private key from buffer "tmp" into RsaKey stucture "key"  */
+    ret = wc_RsaPrivateKeyDecode(tmp, &idx, &key, (word32)bytes);
+    check_ret(ret, "wc_RsaPrivateKeyDecode");
+
+    /* Initialize the RNG structure */
+    ret = wc_InitRng(&rng);
+    check_ret(ret, "wc_InitRng");
+
+    /* Implement RSA blinding to defeat side-channel attacks */
+#ifdef WC_RSA_BLINDING /* HIGHLY RECOMMENDED! */
+    ret = wc_RsaSetRNG(&key, &rng);
+    check_ret(ret, "wc_RsaSetRNG");
+#endif
+
+    /* Sign the AES key effectively "Encrypting it with the private key" */
+    ret = wc_RsaSSL_Sign(in, inLen, out, outSz, &key, &rng);
+    check_ret(ret, "wc_RsaSSL_Sign");
+// WRITE OUT TO FILE!
+    fStream = fopen(fName, "wb");
+    if (!fStream) {
+        printf("Failed to open file: %s\n", fName);
+        return -99;
+    }
+    ret = (int) fwrite(out, 1, RSA_TEST_BYTES, fStream);
+    check_ret(ret, "fwrite the rsa key to file");
+    fclose(fStream);
+
+//    idx = (word32)ret;
+//IDX should be 256 here!
+//    XMEMSET(plain, 0, plainSz);
+
+//    ret = wc_RsaSSL_Verify(out, idx, plain, plainSz, &key);
+//    check_ret(ret, "wc_RsaSSL_Verify");
+//check_buf((char*)out, "out"); OUT=ENCRYPTED
+//check_buf((char*)plain, "plain"); PLAIN=DECRYPTED
+
+    return ret;
+}
+
+void check_ret(int val, char* fail)
+{
+    if (val < 0) {
+        printf("%s Failed with error %d\n", fail, val);
+        exit(-99);
+    }
+    return;
+}

--- a/signature/encryption-through-signing/rsa-private-encrypt-app.c
+++ b/signature/encryption-through-signing/rsa-private-encrypt-app.c
@@ -72,7 +72,8 @@ int main(void)
     /* Sign the AES key effectively "Encrypting it with the private key" */
     ret = wc_RsaSSL_Sign(in, inLen, out, outSz, &key, &rng);
     check_ret(ret, "wc_RsaSSL_Sign");
-// WRITE OUT TO FILE!
+
+    /* Output to file */
     fStream = fopen(fName, "wb");
     if (!fStream) {
         printf("Failed to open file: %s\n", fName);
@@ -81,15 +82,6 @@ int main(void)
     ret = (int) fwrite(out, 1, RSA_TEST_BYTES, fStream);
     check_ret(ret, "fwrite the rsa key to file");
     fclose(fStream);
-
-//    idx = (word32)ret;
-//IDX should be 256 here!
-//    XMEMSET(plain, 0, plainSz);
-
-//    ret = wc_RsaSSL_Verify(out, idx, plain, plainSz, &key);
-//    check_ret(ret, "wc_RsaSSL_Verify");
-//check_buf((char*)out, "out"); OUT=ENCRYPTED
-//check_buf((char*)plain, "plain"); PLAIN=DECRYPTED
 
     return ret;
 }

--- a/signature/encryption-through-signing/rsa-public-decrypt-app.c
+++ b/signature/encryption-through-signing/rsa-public-decrypt-app.c
@@ -1,0 +1,79 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+
+#include <wolfssl/options.h>
+#include <wolfssl/wolfcrypt/rsa.h>
+#include <wolfssl/ssl.h>
+/* certs_test.h contains der formatted key buffer rsa_key_der_2048 */
+#ifdef USE_CERT_BUFFERS_2048
+#include <wolfssl/certs_test.h>
+#else
+    #error "Please define USE_CERT_BUFFERS_2048 when building wolfSSL!"
+#endif
+
+void check_ret(int val, char* fail);
+
+#define RSA_TEST_BYTES 256 /* 256 bytes * 8 = 2048-bit key length */
+#define HEAP_HINT NULL
+
+int main(void)
+{
+    int    ret;
+    size_t bytes;
+    RsaKey key;
+    word32 idx = 0;
+    const word32 plainSz = RSA_TEST_BYTES;
+
+    byte tmp[sizeof_client_keypub_der_2048];
+    byte out[RSA_TEST_BYTES];
+    byte plain[RSA_TEST_BYTES];
+
+    char fName[] = "encryptedAesKey";
+    FILE* fStream;
+
+    /* initialize stack structures */
+    XMEMSET(&key, 0, sizeof(key));
+    XMEMSET(&out, 0, sizeof(out));
+    XMEMSET(&plain, 0, sizeof(plain));
+
+    bytes = (size_t)sizeof_client_keypub_der_2048;
+
+    /* Copy in existing Public RSA key into "tmp" to use for decrypting */
+    XMEMCPY(tmp, client_keypub_der_2048, (size_t)sizeof_client_keypub_der_2048);
+
+    /* Initialize the RSA key structure */
+    ret = wc_InitRsaKey(&key, HEAP_HINT);
+    check_ret(ret, "wc_InitRsaKey_ex");
+
+    /* Decode the public key from buffer "tmp" into RsaKey stucture "key"  */
+    ret = wc_RsaPublicKeyDecode(tmp, &idx, &key, (word32)bytes);
+    check_ret(ret, "wc_RsaPrivateKeyDecode");
+
+    fStream = fopen(fName, "rb");
+    if (!fStream) {
+        printf("Failed to open file: %s\n", fName);
+        return -99;
+    }
+    ret = (int) fread(out, 1, RSA_TEST_BYTES, fStream);
+    check_ret(ret, "fread the rsa key to file");
+    fclose(fStream);
+
+    idx = (word32)ret; /* number of bytes read in from the file */
+    XMEMSET(plain, 0, plainSz);
+
+    ret = wc_RsaSSL_Verify(out, idx, plain, plainSz, &key);
+    check_ret(ret, "wc_RsaSSL_Verify");
+    printf("Here is the recovered AES KEY!\n%s\n", plain);
+
+    return ret;
+}
+
+void check_ret(int val, char* fail)
+{
+    if (val < 0) {
+        printf("%s Failed with error %d\n", fail, val);
+        exit(-99);
+    }
+    return;
+}


### PR DESCRIPTION
USE CASE:
A 32-byte input (AES key) needs to be transported from one device to another securely where the origin device has the private RSA key and the destination device only has a copy of the corresponding RSA public key.
 