### PR TITLE
added define fixes to stop errors when executing make in tls dir

### DIFF
--- a/tls/client-tls-perf.c
+++ b/tls/client-tls-perf.c
@@ -157,13 +157,17 @@ static wolfSSL_method_func SSL_GetMethod(int version)
     #endif
 
     #ifndef NO_TLS
+        #ifdef WOLFSSL_ALLOW_TLSV10
         case 1:
             method = wolfTLSv1_client_method_ex;
             break;
+        #endif
 
+        #ifndef NO_OLD_TLS
         case 2:
             method = wolfTLSv1_1_client_method_ex;
             break;
+        #endif
     #endif
 #endif
 

--- a/tls/server-tls-epoll-perf.c
+++ b/tls/server-tls-epoll-perf.c
@@ -164,13 +164,17 @@ static wolfSSL_method_func SSL_GetMethod(int version, int allowDowngrade)
     #endif
 
     #ifndef NO_TLS
+        #ifdef WOLFSSL_ALLOW_TLSV10
         case 1:
             method = wolfTLSv1_server_method_ex;
             break;
+        #endif
 
+        #ifndef NO_OLD_TLS
         case 2:
             method = wolfTLSv1_1_server_method_ex;
             break;
+        #endif
     #endif
 #endif
 

--- a/tls/server-tls-epoll-threaded.c
+++ b/tls/server-tls-epoll-threaded.c
@@ -212,13 +212,17 @@ static wolfSSL_method_func SSL_GetMethod(int version, int allowDowngrade)
     #endif
 
     #ifndef NO_TLS
+        #ifdef WOLFSSL_ALLOW_TLSV10
         case 1:
             method = wolfTLSv1_server_method_ex;
             break;
+        #endif
 
+        #ifndef NO_OLD_TLS
         case 2:
             method = wolfTLSv1_1_server_method_ex;
             break;
+        #endif
     #endif
 #endif
 


### PR DESCRIPTION
When running the Makefile in the TLS directory with --enable-all configured in wolfSSL, there were errors involving older TLS methods. The define statements added enable successful compilation.