### PR TITLE
sgx_t.mk fixed

### DIFF
--- a/SGX_Linux/sgx_t.mk
+++ b/SGX_Linux/sgx_t.mk
@@ -68,7 +68,7 @@ Wolfssl_Enclave_C_Flags := $(Flags_Just_For_C) $(Common_C_Cpp_Flags) $(Wolfssl_C
 Wolfssl_Enclave_Link_Flags := $(SGX_COMMON_CFLAGS) -Wl,--no-undefined -nostdlib -nodefaultlibs -nostartfiles -L$(SGX_LIBRARY_PATH) \
 	-L$(SGX_WOLFSSL_LIB) -lwolfssl.sgx.static.lib \
 	-Wl,--whole-archive -l$(Trts_Library_Name) -Wl,--no-whole-archive \
-	-Wl,--start-group -lsgx_tstdc -lsgx_tstdcxx -l$(Crypto_Library_Name) -l$(Service_Library_Name) -Wl,--end-group \
+	-Wl,--start-group -lsgx_tstdc -lsgx_tcxx -l$(Crypto_Library_Name) -l$(Service_Library_Name) -Wl,--end-group \
 	-Wl,-Bstatic -Wl,-Bsymbolic -Wl,--no-undefined \
 	-Wl,-pie,-eenclave_entry -Wl,--export-dynamic  \
 	-Wl,--defsym,__ImageBase=0 \


### PR DESCRIPTION
There is following compile error in sgx_t.mk with a recent SGX SDK 2.4 in Ubuntu 18.04.
"/usr/bin/ld: cannot find -lsgx_tstdcxx"

Maybe the Linking option "-lsgx_tstdcxx" is no more supported over SGX SDK 2.0.100.40950
as a following the Intel Release Note for SGX SDK 1.9.100.39124.
"Note that the Standard C++ Library based on STLPort (sgx_tstdcxx) will be deprecated in the next release"

So, the option "-lsgx_tstdcxx" must be changed to "-lsgx_tcxx".

Thank you.