### PR TITLE
Fixes for the server examples using incorrect length for reply memcpy

### DIFF
--- a/SGX_Linux/untrusted/server-tls.c
+++ b/SGX_Linux/untrusted/server-tls.c
@@ -54,6 +54,7 @@ int server_connect(sgx_enclave_id_t id)
     char               buff[256];
     size_t             len;
     int                ret = 0;                        /* variable for error checking */
+    const char*        reply = "I hear ya fa shizzle!\n";
 
     /* declare wolfSSL objects */
     WOLFSSL_CTX* ctx;
@@ -168,7 +169,7 @@ int server_connect(sgx_enclave_id_t id)
 
     /* Write our reply into buff */
     memset(buff, 0, sizeof(buff));
-    memcpy(buff, "I hear ya fa shizzle!\n", sizeof(buff));
+    memcpy(buff, reply, strlen(reply));
     len = strnlen(buff, sizeof(buff));
 
     /* Reply back to the client */

--- a/pkcs11/server-tls-pkcs11-ecc.c
+++ b/pkcs11/server-tls-pkcs11-ecc.c
@@ -53,6 +53,7 @@ int server_tls(int devId, Pkcs11Token* token)
     int                shutdown = 0;
     int                ret;
     unsigned char      privKeyId[] = PRIV_KEY_ID;
+    const char*        reply = "I hear ya fa shizzle!\n";
 
     /* declare wolfSSL objects */
     WOLFSSL_CTX* ctx;
@@ -187,7 +188,7 @@ int server_tls(int devId, Pkcs11Token* token)
 
         /* Write our reply into buff */
         memset(buff, 0, sizeof(buff));
-        memcpy(buff, "I hear ya fa shizzle!\n", sizeof(buff));
+        memcpy(buff, reply, strlen(reply));
         len = strnlen(buff, sizeof(buff));
 
         /* Reply back to the client */

--- a/pkcs11/server-tls-pkcs11.c
+++ b/pkcs11/server-tls-pkcs11.c
@@ -53,6 +53,7 @@ int server_tls(int devId, Pkcs11Token* token)
     int                shutdown = 0;
     int                ret;
     unsigned char      privKeyId[] = PRIV_KEY_ID;
+    const char*        reply = "I hear ya fa shizzle!\n";
 
     /* declare wolfSSL objects */
     WOLFSSL_CTX* ctx;
@@ -187,7 +188,7 @@ int server_tls(int devId, Pkcs11Token* token)
 
         /* Write our reply into buff */
         memset(buff, 0, sizeof(buff));
-        memcpy(buff, "I hear ya fa shizzle!\n", sizeof(buff));
+        memcpy(buff, reply, strlen(reply));
         len = strnlen(buff, sizeof(buff));
 
         /* Reply back to the client */

--- a/tls/README.md
+++ b/tls/README.md
@@ -374,7 +374,7 @@ buffer like this:
 ```c
         /* Write our reply into buff */
         memset(buff, 0, sizeof(buff));
-        memcpy(buff, "I hear ya fa shizzle!\n", sizeof(buff));
+        memcpy(buff, reply, strlen(reply));
         len = strnlen(buff, sizeof(buff));
 ```
 

--- a/tls/server-tcp.c
+++ b/tls/server-tcp.c
@@ -44,6 +44,7 @@ int main()
     char               buff[256];
     size_t             len;
     int                shutdown = 0;
+    const char*        reply = "I hear ya fa shizzle!\n";
 
 
 
@@ -116,7 +117,7 @@ int main()
 
         /* Write our reply into buff */
         memset(buff, 0, sizeof(buff));
-        memcpy(buff, "I hear ya fa shizzle!\n", sizeof(buff));
+        memcpy(buff, reply, strlen(reply));
         len = strnlen(buff, sizeof(buff));
 
         /* Reply back to the client */

--- a/tls/server-tls-callback.c
+++ b/tls/server-tls-callback.c
@@ -152,6 +152,7 @@ int main()
     size_t             len;
     int                shutdown = 0;
     int                ret;
+    const char*        reply = "I hear ya fa shizzle!\n";
 
     /* declare wolfSSL objects */
     WOLFSSL_CTX* ctx;
@@ -281,7 +282,7 @@ int main()
 
         /* Write our reply into buff */
         memset(buff, 0, sizeof(buff));
-        memcpy(buff, "I hear ya fa shizzle!\n", sizeof(buff));
+        memcpy(buff, reply, strlen(reply));
         len = strnlen(buff, sizeof(buff));
 
         /* Reply back to the client */

--- a/tls/server-tls-ecdhe.c
+++ b/tls/server-tls-ecdhe.c
@@ -54,6 +54,7 @@ int main()
     size_t             len;
     int                shutdown = 0;
     int                ret;
+    const char*        reply = "I hear ya fa shizzle!\n";
 
     /* declare wolfSSL objects */
     WOLFSSL_CTX* ctx;
@@ -180,7 +181,7 @@ int main()
 
         /* Write our reply into buff */
         memset(buff, 0, sizeof(buff));
-        memcpy(buff, "I hear ya fa shizzle!\n", sizeof(buff));
+        memcpy(buff, reply, strlen(reply));
         len = strnlen(buff, sizeof(buff));
 
         /* Reply back to the client */

--- a/tls/server-tls-nonblocking.c
+++ b/tls/server-tls-nonblocking.c
@@ -53,6 +53,7 @@ int main()
     size_t             len;
     int                shutdown = 0;
     int                ret;
+    const char*        reply = "I hear ya fa shizzle!\n";
 
     /* declare wolfSSL objects */
     WOLFSSL_CTX* ctx;
@@ -188,7 +189,7 @@ int main()
 
         /* Write our reply into buff */
         memset(buff, 0, sizeof(buff));
-        memcpy(buff, "I hear ya fa shizzle!\n", sizeof(buff));
+        memcpy(buff, reply, strlen(reply));
         len = strnlen(buff, sizeof(buff));
 
         /* Reply back to the client */

--- a/tls/server-tls-threaded.c
+++ b/tls/server-tls-threaded.c
@@ -65,6 +65,7 @@ void* ClientHandler(void* args)
     char             buff[256];
     size_t           len;
     int              ret;
+    const char*        reply = "I hear ya fa shizzle!\n";
 
 
     /* Create a WOLFSSL object */
@@ -110,7 +111,7 @@ void* ClientHandler(void* args)
 
     /* Write our reply into buff */
     memset(buff, 0, sizeof(buff));
-    memcpy(buff, "I hear ya fa shizzle!\n", sizeof(buff));
+    memcpy(buff, reply, strlen(reply));
     len = strnlen(buff, sizeof(buff));
 
     /* Reply back to the client */

--- a/tls/server-tls.c
+++ b/tls/server-tls.c
@@ -52,6 +52,7 @@ int main()
     size_t             len;
     int                shutdown = 0;
     int                ret;
+    const char*        reply = "I hear ya fa shizzle!\n";
 
     /* declare wolfSSL objects */
     WOLFSSL_CTX* ctx;
@@ -175,7 +176,7 @@ int main()
 
         /* Write our reply into buff */
         memset(buff, 0, sizeof(buff));
-        memcpy(buff, "I hear ya fa shizzle!\n", sizeof(buff));
+        memcpy(buff, reply, strlen(reply));
         len = strnlen(buff, sizeof(buff));
 
         /* Reply back to the client */


### PR DESCRIPTION
Fixes for the server examples using incorrect length for memcpy operation in reply and reading past const char string. Resolves Jenkins "wolfSSL Examples Repo Test - NIGHTLY BUILD" reports.