### PR TITLE
Fix up build error on dtls/server-dtls-threaded

### DIFF
--- a/dtls/Makefile
+++ b/dtls/Makefile
@@ -28,6 +28,10 @@ all: $(TARGETS)
 debug: CFLAGS+=$(DEBUG_FLAGS)
 debug: all
 
+# add the -pthread flag and -lpthread lib to any threaded examples
+%-threaded: CFLAGS+=-pthread
+%-threaded: LIBS+=-lpthread
+
 # build template
 %: %.c
 	$(CC) -o $@ $< $(CFLAGS) $(LIBS)


### PR DESCRIPTION
When trying to build programs in dtls/, the following error was found:
```
$ cd wolfssl-examples/dtls
$ make
...
gcc -o server-dtls-threaded server-dtls-threaded.c -Wall -I/usr/local/include -Os -L/usr/local/lib -lm -lwolfssl
/usr/bin/ld: /tmp/ccjBDgvS.o: undefined reference to symbol 'pthread_detach@@GLIBC_2.2.5'
/usr/bin/ld: /lib/x86_64-linux-gnu/libpthread.so.0: error adding symbols: DSO missing from command line
collect2: error: ld returned 1 exit status
make: *** [Makefile:33: server-dtls-threaded] Error 1
```
Adding "LIBS+=-lpthread" in dtls/Makefile should fix this problem.

(Tested on Ubuntu 19.04 with libwolfssl-dev_3.15.3+dfsg-2)


