### PR TITLE
Fix sgx library name -lsgx_tstdcxx become -lsgx_tcxx for new version

### DIFF
--- a/SGX_Linux/sgx_t.mk
+++ b/SGX_Linux/sgx_t.mk
@@ -68,7 +68,7 @@ Wolfssl_Enclave_C_Flags := $(Flags_Just_For_C) $(Common_C_Cpp_Flags) $(Wolfssl_C
 Wolfssl_Enclave_Link_Flags := $(SGX_COMMON_CFLAGS) -Wl,--no-undefined -nostdlib -nodefaultlibs -nostartfiles -L$(SGX_LIBRARY_PATH) \
 	-L$(SGX_WOLFSSL_LIB) -lwolfssl.sgx.static.lib \
 	-Wl,--whole-archive -l$(Trts_Library_Name) -Wl,--no-whole-archive \
-	-Wl,--start-group -lsgx_tstdc -lsgx_tstdcxx -l$(Crypto_Library_Name) -l$(Service_Library_Name) -Wl,--end-group \
+	-Wl,--start-group -lsgx_tstdc -lsgx_tcxx -l$(Crypto_Library_Name) -l$(Service_Library_Name) -Wl,--end-group \
 	-Wl,-Bstatic -Wl,-Bsymbolic -Wl,--no-undefined \
 	-Wl,-pie,-eenclave_entry -Wl,--export-dynamic  \
 	-Wl,--defsym,__ImageBase=0 \


### PR DESCRIPTION
New version sgx sdk the library name sgx_tstdcxx have became sgx_tcxx.
Need to fix or the makefile compile will fail.