### PR TITLE
Fix nightly psk build warnings

### DIFF
--- a/psk/client-psk-nonblocking.c
+++ b/psk/client-psk-nonblocking.c
@@ -40,7 +40,7 @@
  * enum used for tcp_select function
  */
 enum {
-    TEST_SELECT_FAIL,
+    TEST_SELECT_FAIL = 0,
     TEST_TIMEOUT,
     TEST_RECV_READY,
     TEST_ERROR_READY
@@ -72,7 +72,8 @@ static inline unsigned int My_Psk_Client_Cb(WOLFSSL* ssl, const char* hint,
 
 int main(int argc, char **argv)
 {
-    int sockfd, ret, error, select_ret, currTimeout;
+    int sockfd, ret, error, currTimeout;
+    int select_ret = TEST_SELECT_FAIL;
     int nfds;
     int result;
     char sendline[MAXLINE]="Hello Server"; /* string to send to the server */

--- a/psk/server-psk-nonblocking.c
+++ b/psk/server-psk-nonblocking.c
@@ -43,7 +43,7 @@
 
 /* states of the tcp connection */
 enum{
-    TEST_SELECT_FAIL,
+    TEST_SELECT_FAIL = 0,
     TEST_TIMEOUT,
     TEST_RECV_READY,
     TEST_ERROR_READY
@@ -77,7 +77,7 @@ int main()
     int ret;
     int error;
     int result;
-    int select_ret;
+    int select_ret = TEST_SELECT_FAIL;
     int sockfd;
     int nfds;
     int currTimeout = 1;


### PR DESCRIPTION
This PR fixes two build warnings listed below: 

```
server-psk-nonblocking.c: In function ‘main’:

server-psk-nonblocking.c:260:29: warning: ‘select_ret’ may be used uninitialized in this function [-Wmaybe-uninitialized]
                     else if (select_ret == TEST_TIMEOUT) {
                             ^
gcc -o server-tcp server-tcp.c -Wall -I/var/lib/jenkins/workspace/nightly-CDT-wolfssl-examples-repo-v-1-1/install-dir/include -Os -pthread -L/var/lib/jenkins/workspace/nightly-CDT-wolfssl-examples-repo-v-1-1/install-dir/lib -lm -lwolfssl
gcc -o server-psk server-psk.c -Wall -I/var/lib/jenkins/workspace/nightly-CDT-wolfssl-examples-repo-v-1-1/install-dir/include -Os -pthread -L/var/lib/jenkins/workspace/nightly-CDT-wolfssl-examples-repo-v-1-1/install-dir/lib -lm -lwolfssl
gcc -o client-psk-nonblocking client-psk-nonblocking.c -Wall -I/var/lib/jenkins/workspace/nightly-CDT-wolfssl-examples-repo-v-1-1/install-dir/include -Os -pthread -L/var/lib/jenkins/workspace/nightly-CDT-wolfssl-examples-repo-v-1-1/install-dir/lib -lm -lwolfssl
client-psk-nonblocking.c: In function ‘main’:

client-psk-nonblocking.c:207:17: warning: ‘select_ret’ may be used uninitialized in this function [-Wmaybe-uninitialized]
         else if (select_ret == TEST_TIMEOUT) {
                 ^
```