### PR TITLE
ECC examples for raw sign/verify

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -170,6 +170,9 @@ pk/rsa-pss/rsa-pss
 pk/rsa-pss/rsa-public.der
 pk/rsa-pss/sign.txt
 pk/rsa/rsa-nb
+pk/ecc/ecc_verify
+pk/ecc/ecc_sign
+pk/ecc/ecc_pub
 pk/ecc/ecc_keys
 #Example der and x963 files
 pk/ecc/*.der

--- a/ecc/ecc-sign.c
+++ b/ecc/ecc-sign.c
@@ -78,7 +78,7 @@ static void PrintBuffer(const byte* buffer, word32 length)
 static int HashFirmware(byte* hashBuf)
 {
     int ret;
-    Sha256 sha;
+    wc_Sha256 sha;
     int idx = 0, len = gFwLen, sz;
 
     ret = wc_InitSha256(&sha);
@@ -151,8 +151,8 @@ static int SignFirmware(byte* hashBuf, word32 hashLen, byte* sigBuf, word32* sig
 int main(void)
 {
     int ret;
-    byte hashBuf[SHA256_DIGEST_SIZE];
-    word32 hashLen = SHA256_DIGEST_SIZE;
+    byte hashBuf[WC_SHA256_DIGEST_SIZE];
+    word32 hashLen = WC_SHA256_DIGEST_SIZE;
     byte sigBuf[ECC_MAX_SIG_SIZE];
     word32 sigLen = ECC_MAX_SIG_SIZE;
     int i;
@@ -162,7 +162,7 @@ int main(void)
         gFwBuf[i] = (byte)i;
     }
 
-    /* try perofrming signature a few times */
+    /* try performing signature a few times */
     for (i=0; i < gSignTimes; i++) {
         memset(hashBuf, 0, hashLen);
         ret = HashFirmware(hashBuf);

--- a/pk/ecc/Makefile
+++ b/pk/ecc/Makefile
@@ -1,6 +1,7 @@
 CC=gcc
-CFLAGS=-Wall
-LIBS= -lwolfssl
+WOLF_PATH=/usr/local
+CFLAGS=-I$(WOLF_PATH)/include -Wall
+LIBS=-L$(WOLF_PATH)/lib -lwolfssl
 
 SRC=$(wildcard *.c)
 TARGETS=$(patsubst %.c, %, $(SRC))

--- a/pk/ecc/Makefile
+++ b/pk/ecc/Makefile
@@ -2,10 +2,15 @@ CC=gcc
 CFLAGS=-Wall
 LIBS= -lwolfssl
 
-ecc_keys: ecc_keys.o
+SRC=$(wildcard *.c)
+TARGETS=$(patsubst %.c, %, $(SRC))
+
+all: $(TARGETS)
+
+%: %.c
 	$(CC) -o $@ $^ $(CFLAGS) $(LIBS)
 
 .PHONY: clean
 
 clean:
-	rm -f *.der *.x963 *.o ecc_keys
+	rm -f $(TARGETS) *.der *.x963 

--- a/pk/ecc/README
+++ b/pk/ecc/README
@@ -1,8 +1,0 @@
-Shows examples of how to work with storing and loading keys after they have been generated. ecc_keys.c creates a key structure than stores the private key in DER formate. After storing the private key it then loads it back into a ecc_key struct. ecc_keys.c also shows how to export and import public keys.
-
-The build option used for wolfSSL is
-
-```
-./configure --enable-keygen --enable-ecc
-```
-

--- a/pk/ecc/README.md
+++ b/pk/ecc/README.md
@@ -20,8 +20,12 @@ The `ecc_keys.c` example shows how to work with storing and loading keys after t
 
 ## ecc_sign
 
-The `ecc_verify.c` example uses NIST test vectors to demonstrate hashing a message and verifying an ECC signature.
+The `ecc_sign.c:` example takes a random message and private key, creates a signature then verifies it.
 
 ## ecc_verify
 
-The `ecc_sign.c:` example takes a random message and private key, creates a signature then verifies it.
+The `ecc_verify.c` example uses NIST test vectors to demonstrate hashing a message and verifying an ECC signature.
+
+## ecc_pub
+
+The `ecc_pub` example code shows how to extracting an ECC public key from private key.

--- a/pk/ecc/README.md
+++ b/pk/ecc/README.md
@@ -1,0 +1,27 @@
+# Asymmetric ECC Examples
+
+The build option used for wolfSSL are:
+
+```
+./configure --enable-ecc CFLAGS="-DWOLFSSL_PUBLIC_MP"
+make
+sudo make install
+sudo ldconfig
+```
+
+
+## ecc_keys
+
+The `ecc_keys.c` example shows how to work with storing and loading keys after they have been generated.
+
+1. Creates a key structure
+2. Stores the private key in DER format.
+3. Loads DER private key back into a ecc_key struct.
+
+## ecc_sign
+
+The `ecc_verify.c` example uses NIST test vectors to demonstrate hashing a message and verifying an ECC signature.
+
+## ecc_verify
+
+The `ecc_sign.c:` example takes a random message and private key, creates a signature then verifies it.

--- a/pk/ecc/ecc_pub.c
+++ b/pk/ecc/ecc_pub.c
@@ -1,0 +1,107 @@
+/* ecc_pub.c
+ *
+ * Copyright (C) 2006-2020 wolfSSL Inc.
+ *
+ * This file is part of wolfSSL. (formerly known as CyaSSL)
+ *
+ * wolfSSL is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * wolfSSL is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
+ */
+
+/* example code for extracting public from private */
+/* 
+./configure && make && sudo make install
+gcc -lwolfssl -o ecc_pub ecc_pub.c
+*/
+
+#ifndef WOLFSSL_USER_SETTINGS
+    #include <wolfssl/options.h>
+#endif
+#include <wolfssl/wolfcrypt/settings.h>
+#include <wolfssl/wolfcrypt/ecc.h>
+#include <wolfssl/wolfcrypt/logging.h>
+
+#include <stdint.h>
+#include <stdio.h>
+
+#define ECC_CURVE_SZ 32 /* SECP256R1 curve size in bytes */
+#define ECC_CURVE_ID ECC_SECP256R1
+
+/* Private key "d" only */
+static const uint8_t kPrivKey[] = {
+    /* d */
+    0x1e, 0xe7, 0x70, 0x07, 0xd3, 0x30, 0x94, 0x39, 
+    0x28, 0x90, 0xdf, 0x23, 0x88, 0x2c, 0x4a, 0x34, 
+    0x15, 0xdb, 0x4c, 0x43, 0xcd, 0xfa, 0xe5, 0x1f, 
+    0x3d, 0x4c, 0x37, 0xfe, 0x59, 0x3b, 0x96, 0xd8
+};
+
+static void print_hex(uint8_t* data, int sz)
+{
+    int i;
+    for (i = 0; i < sz; i++) {
+        printf("%02X ", data[i]);
+        if (i > 0 && ((i+1) % 16) == 0)
+            printf("\n");
+    }
+    printf("\n");
+}
+
+int main()
+{
+#if defined(HAVE_ECC) && defined(HAVE_ECC_KEY_EXPORT)
+    int ret;
+    ecc_key ecc;
+    uint8_t pubKey[ECC_CURVE_SZ*2];
+    uint32_t pubQxSz = ECC_CURVE_SZ, pubQySz = ECC_CURVE_SZ;
+
+    /* Setup the ECC key */
+    ret = wc_ecc_init(&ecc);
+    if (ret < 0) {
+        return ret;
+    }
+
+    memset(pubKey, 0, sizeof(pubKey));
+
+    /* Import private key "k" */
+    ret = wc_ecc_import_private_key_ex(
+        kPrivKey, sizeof(kPrivKey), /* private key "d" */
+        NULL, 0,                    /* public (optional) */
+        &ecc,
+        ECC_CURVE_ID
+    );
+
+    /* Export public key */
+    if (ret == 0) {
+        ret = wc_ecc_make_pub(&ecc, NULL);
+    }
+    if (ret == 0) {
+        ret = wc_ecc_export_public_raw(&ecc, 
+            pubKey, &pubQxSz,               /* public Qx */
+            pubKey+ECC_CURVE_SZ, &pubQySz   /* public Qy */
+        );
+    }
+
+    printf("Public Key Qx: %d\n", pubQxSz);
+    print_hex(pubKey, ECC_CURVE_SZ);
+    printf("Public Key Qy: %d\n", pubQySz);
+    print_hex(pubKey+ECC_CURVE_SZ, ECC_CURVE_SZ);
+
+    wc_ecc_free(&ecc);
+    return ret;
+#else
+    printf("wolfSSL needs to be built with ECC and key export enabled\n");
+    return -1;
+#endif /* HAVE_ECC && HAVE_ECC_KEY_EXPORT */
+}

--- a/pk/ecc/ecc_sign.c
+++ b/pk/ecc/ecc_sign.c
@@ -295,13 +295,15 @@ int main()
     int ret;
     uint8_t hash[WC_SHA256_DIGEST_SIZE];
     uint8_t sig[ECC_CURVE_SZ*2];
-    uint32_t sigSz = sizeof(sig);
+    uint32_t sigSz = 0;
 
 #ifdef DEBUG_WOLFSSL
     wolfSSL_Debugging_ON();
 #endif
 
     printf("Running NIST P-256,SHA-256 Sign Test\n");
+
+    memset(sig, 0, sizeof(sig));
 
     ret = crypto_sha256(
         kMsg, sizeof(kMsg), /* input message */
@@ -313,6 +315,7 @@ int main()
         /* Note: result of an ECC sign varies for each call even with same 
             private key and hash. This is because a new random public key is 
             used for each operation. */ 
+        sigSz = sizeof(sig);
         ret = crypto_ecc_sign(
             kPrivKey, sizeof(kPrivKey), /* private key */
             hash, sizeof(hash),         /* computed hash digest */
@@ -333,16 +336,18 @@ int main()
         );
     }
 
-    printf("Signature %d\n", sigSz);
-    print_hex(sig, sigSz);
+    if (ret == 0) {
+        printf("Signature %d\n", sigSz);
+        print_hex(sig, sigSz);
 
-    if (ret != 0) {
-        printf("Failure %d: %s\n", ret, wc_GetErrorString(ret));
-        return -1;
+        printf("Success\n");
     }
-    printf("Success\n");
+    else {
+        printf("Failure %d: %s\n", ret, wc_GetErrorString(ret));
+        ret = -1;
+    }
 
-    return 0;
+    return ret;
 #else
     printf("wolfSSL requires ECC and SHA256\n");
     return -1;

--- a/pk/ecc/ecc_sign.c
+++ b/pk/ecc/ecc_sign.c
@@ -1,0 +1,350 @@
+/* ecc_sign.c
+ *
+ * Copyright (C) 2006-2020 wolfSSL Inc.
+ *
+ * This file is part of wolfSSL. (formerly known as CyaSSL)
+ *
+ * wolfSSL is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * wolfSSL is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
+ */
+
+/* Example to demonstrate SHA-256 hashing and ECC Sign */
+/* 
+./configure CFLAGS="-DWOLFSSL_PUBLIC_MP" && make && sudo make install
+gcc -lwolfssl -o ecc_sign ecc_sign.c
+*/
+
+#ifndef WOLFSSL_USER_SETTINGS
+    #include <wolfssl/options.h>
+#endif
+#include <wolfssl/wolfcrypt/settings.h>
+#include <wolfssl/wolfcrypt/sha256.h>
+#include <wolfssl/wolfcrypt/ecc.h>
+#include <wolfssl/wolfcrypt/integer.h>
+#include <wolfssl/wolfcrypt/error-crypt.h>
+#include <wolfssl/wolfcrypt/logging.h>
+
+#include <stdint.h>
+#include <stdio.h>
+
+#define ECC_CURVE_SZ 32 /* SECP256R1 curve size in bytes */
+#define ECC_CURVE_ID ECC_SECP256R1
+
+
+/* Test Vector */
+/* NIST P-256, SHA256 ECC Test Vector */
+static const uint8_t kMsg[] = {
+    0x69, 0xbc, 0x9f, 0xce, 0x68, 0x17, 0xc2, 0x10, 0xea, 0xfc, 0x10, 0x65, 0x67, 0x52, 0xed, 0x78, 
+    0x6e, 0xb8, 0x83, 0x9c, 0x9a, 0xb4, 0x56, 0x0d, 0xc1, 0x0d, 0x1f, 0x78, 0x6e, 0x75, 0xd7, 0xbe, 
+    0x92, 0x6b, 0x12, 0xf6, 0x76, 0x60, 0x8e, 0xb1, 0xf4, 0x19, 0x0c, 0x81, 0xe7, 0x54, 0x5e, 0xbc, 
+    0xe0, 0xae, 0xc2, 0x7d, 0x1b, 0xc4, 0x6e, 0xec, 0xb1, 0x99, 0x6c, 0xbf, 0x0e, 0x38, 0xa8, 0x01, 
+    0xa6, 0x9a, 0x48, 0x12, 0xe4, 0xc9, 0x3b, 0xf0, 0x63, 0x46, 0x15, 0xb4, 0x61, 0xa8, 0x1a, 0x60, 
+    0x71, 0x87, 0x98, 0xd7, 0x6f, 0x98, 0x7b, 0x2d, 0xb9, 0x19, 0x1b, 0x21, 0x9c, 0x70, 0x58, 0xe8, 
+    0x0d, 0x0f, 0xe9, 0x2d, 0x9a, 0x9a, 0xf1, 0x55, 0xa0, 0x4c, 0xd3, 0x07, 0xbd, 0x97, 0x48, 0xec, 
+    0x88, 0x0a, 0xaf, 0xb3, 0x80, 0x78, 0xa4, 0x59, 0x43, 0x57, 0xd3, 0xa7, 0x01, 0x66, 0x0e, 0xfc
+};
+static const uint8_t kPrivKey[] = {
+    /* d */
+    0x1e, 0xe7, 0x70, 0x07, 0xd3, 0x30, 0x94, 0x39, 
+    0x28, 0x90, 0xdf, 0x23, 0x88, 0x2c, 0x4a, 0x34, 
+    0x15, 0xdb, 0x4c, 0x43, 0xcd, 0xfa, 0xe5, 0x1f, 
+    0x3d, 0x4c, 0x37, 0xfe, 0x59, 0x3b, 0x96, 0xd8
+};
+static const uint8_t kPubKey[] = {
+    /* Qx */
+    0x96, 0x93, 0x1c, 0x53, 0x0b, 0x43, 0x6c, 0x42, 
+    0x0c, 0x52, 0x90, 0xe4, 0xa7, 0xec, 0x98, 0xb1, 
+    0xaf, 0xd4, 0x14, 0x49, 0xd8, 0xc1, 0x42, 0x82, 
+    0x04, 0x78, 0xd1, 0x90, 0xae, 0xa0, 0x6c, 0x07, 
+    /* Qy */
+    0xf2, 0x3a, 0xb5, 0x10, 0x32, 0x8d, 0xce, 0x9e, 
+    0x76, 0xa0, 0xd2, 0x8c, 0xf3, 0xfc, 0xa9, 0x94, 
+    0x43, 0x24, 0xe6, 0x82, 0x00, 0x40, 0xc6, 0xdb, 
+    0x1c, 0x2f, 0xcd, 0x38, 0x4b, 0x60, 0xdd, 0x61
+};
+
+
+#ifndef NO_SHA256
+/* perform hashing block by block */
+int crypto_sha256(const uint8_t *buf, uint32_t len, uint8_t *hash, 
+    uint32_t hashSz, uint32_t blkSz)
+{
+    int ret;
+    uint32_t i = 0, chunk;
+    wc_Sha256 sha256;
+    
+    /* validate arguments */
+    if ((buf == NULL && len > 0) || hash == NULL || 
+        hashSz < WC_SHA256_DIGEST_SIZE || blkSz == 0)
+    {
+        return BAD_FUNC_ARG;
+    }
+
+    /* Init Sha256 structure */
+    ret = wc_InitSha256(&sha256);
+    if (ret != 0) {
+        return ret;
+    }
+    while (i < len) {
+        chunk = blkSz;
+        if ((chunk + i) > len)
+            chunk = len - i;
+        /* Perform chunked update */
+        ret = wc_Sha256Update(&sha256, (buf + i), chunk);
+        if (ret != 0) {
+            break;
+        }
+        i += chunk;
+    }
+    if (ret == 0) {
+        /* Get final digest result */
+        ret = wc_Sha256Final(&sha256, hash);
+    }
+    return ret;
+}
+#endif
+
+#ifdef HAVE_ECC
+#ifdef HAVE_ECC_VERIFY
+/* perform verify of signature and hash using public key */
+/* key is public Qx + public Qy */
+/* sig is r + s */
+int crypto_ecc_verify(const uint8_t *key, uint32_t keySz,
+    const uint8_t *hash, uint32_t hashSz, const uint8_t *sig, uint32_t sigSz,
+    int curveSz, int curveId)
+{
+    int ret, verify_res = 0;
+    mp_int r, s;
+    ecc_key ecc;
+
+    /* validate arguments */
+    if (key == NULL || hash == NULL || sig == NULL || curveSz == 0 || 
+        hashSz == 0 || keySz < (curveSz*2) || sigSz < (curveSz*2))
+    {
+        return BAD_FUNC_ARG;
+    }
+
+    /* Setup the ECC key */
+    ret = wc_ecc_init(&ecc);
+    if (ret < 0) {
+        return ret;
+    }
+
+    /* Setup the signature r/s variables */
+    ret = mp_init(&r);
+    if (ret != MP_OKAY) {
+        wc_ecc_free(&ecc);
+        return ret;
+    }
+    ret = mp_init(&s);
+    if (ret != MP_OKAY) {
+        mp_clear(&r);
+        wc_ecc_free(&ecc);
+        return ret;
+    }
+
+    /* Import public key x/y */
+    ret = wc_ecc_import_unsigned(
+        &ecc, 
+        (byte*)key,             /* Public "x" Coordinate */
+        (byte*)(key + curveSz), /* Public "y" Coordinate */
+        NULL,                   /* Private "d" (optional) */
+        curveId                 /* ECC Curve Id */
+    );
+    /* Make sure it was a public key imported */
+    if (ret == 0 && ecc.type != ECC_PUBLICKEY) {
+        ret = ECC_BAD_ARG_E;
+    }
+
+    /* Import signature r/s */
+    if (ret == 0) {
+        ret = mp_read_unsigned_bin(&r, sig,  curveSz);
+    }
+    if (ret == 0) {
+        ret = mp_read_unsigned_bin(&s, sig + curveSz, curveSz);
+    }
+
+    /* Verify ECC Signature */
+    if (ret == 0) {
+        ret = wc_ecc_verify_hash_ex(
+            &r, &s,       /* r/s as mp_int */
+            hash, hashSz, /* computed hash digest */
+            &verify_res,  /* verification result 1=success */
+            &ecc
+        );
+    }
+    
+    /* check verify result */
+    if (ret == 0 && verify_res == 0) {
+        ret = SIG_VERIFY_E;
+    }
+
+    mp_clear(&r);
+    mp_clear(&s);
+    wc_ecc_free(&ecc);
+
+    return ret;
+}
+#endif /* HAVE_ECC_VERIFY */
+
+#ifdef HAVE_ECC_SIGN
+/* perform signature operation against hash using private key */
+int crypto_ecc_sign(const uint8_t *key, uint32_t keySz,
+    const uint8_t *hash, uint32_t hashSz, uint8_t *sig, uint32_t* sigSz,
+    int curveSz, int curveId)
+{
+    int ret;
+    mp_int r, s;
+    ecc_key ecc;
+    WC_RNG rng;
+
+    /* validate arguments */
+    if (key == NULL || hash == NULL || sig == NULL || sigSz == NULL ||
+        curveSz == 0 || hashSz == 0 || keySz < curveSz || *sigSz < (curveSz*2))
+    {
+        return BAD_FUNC_ARG;
+    }
+
+    /* Initialize signature result */
+    memset(sig, 0, curveSz*2);
+
+    /* Setup the RNG */
+    ret = wc_InitRng(&rng);
+    if (ret < 0) {
+        return ret;
+    }
+
+    /* Setup the ECC key */
+    ret = wc_ecc_init(&ecc);
+    if (ret < 0) {
+        wc_FreeRng(&rng);
+        return ret;
+    }
+
+    /* Setup the signature r/s variables */
+    ret = mp_init(&r);
+    if (ret != MP_OKAY) {
+        wc_ecc_free(&ecc);
+        wc_FreeRng(&rng);
+        return ret;
+    }
+    ret = mp_init(&s);
+    if (ret != MP_OKAY) {
+        mp_clear(&r);
+        wc_ecc_free(&ecc);
+        wc_FreeRng(&rng);
+        return ret;
+    }
+
+    /* Import private key "k" */
+    ret = wc_ecc_import_private_key_ex(
+        key, keySz, /* private key "d" */
+        NULL, 0,    /* public (optional) */
+        &ecc,
+        curveId     /* ECC Curve Id */
+    );
+    if (ret == 0) {
+        /* Verify ECC Signature */
+        ret = wc_ecc_sign_hash_ex(
+            hash, hashSz, /* computed hash digest */
+            &rng, &ecc,   /* random and key context */
+            &r, &s        /* r/s as mp_int */
+        );
+
+        /* export r/s */
+        mp_to_unsigned_bin(&r, sig);
+        mp_to_unsigned_bin(&s, sig + curveSz);
+    }
+    
+    mp_clear(&r);
+    mp_clear(&s);
+    wc_ecc_free(&ecc);
+    wc_FreeRng(&rng);
+
+    return ret;
+}
+#endif /* HAVE_ECC_SIGN */
+#endif /* HAVE_ECC */
+
+static void print_hex(uint8_t* data, int sz)
+{
+    int i;
+    for (i = 0; i < sz; i++) {
+        printf("%02X ", data[i]);
+        if (i > 0 && ((i+1) % 16) == 0)
+            printf("\n");
+    }
+    printf("\n");
+}
+
+int main()
+{
+#if defined(HAVE_ECC) && defined(HAVE_ECC_SIGN) && defined(HAVE_ECC_VERIFY) && \
+    !defined(NO_SHA256)
+    int ret;
+    uint8_t hash[WC_SHA256_DIGEST_SIZE];
+    uint8_t sig[ECC_CURVE_SZ*2];
+    uint32_t sigSz = sizeof(sig);
+
+#ifdef DEBUG_WOLFSSL
+    wolfSSL_Debugging_ON();
+#endif
+
+    printf("Running NIST P-256,SHA-256 Sign Test\n");
+
+    ret = crypto_sha256(
+        kMsg, sizeof(kMsg), /* input message */
+        hash, sizeof(hash), /* hash digest result */
+        32                  /* configurable block / chunk size */
+    );
+    if (ret == 0) {
+        /* Sign hash using private key */
+        /* Note: result of an ECC sign varies for each call even with same 
+            private key and hash. This is because a new random public key is 
+            used for each operation. */ 
+        ret = crypto_ecc_sign(
+            kPrivKey, sizeof(kPrivKey), /* private key */
+            hash, sizeof(hash),         /* computed hash digest */
+            sig, &sigSz,                /* signature r/s */
+            ECC_CURVE_SZ,               /* SECP256R1 curve size in bytes */
+            ECC_CURVE_ID                /* curve id */
+        );
+    }
+
+    if (ret == 0) {
+        /* Verify generated signature is valid */
+        ret = crypto_ecc_verify(
+            kPubKey, sizeof(kPubKey),   /* public key point x/y */
+            hash, sizeof(hash),         /* computed hash digest */
+            sig, sigSz,                 /* signature r/s */
+            ECC_CURVE_SZ,               /* curve size in bytes */
+            ECC_CURVE_ID                /* curve id */
+        );
+    }
+
+    printf("Signature %d\n", sigSz);
+    print_hex(sig, sigSz);
+
+    if (ret != 0) {
+        printf("Failure %d: %s\n", ret, wc_GetErrorString(ret));
+        return -1;
+    }
+    printf("Success\n");
+
+    return 0;
+#else
+    printf("wolfSSL requires ECC and SHA256\n");
+    return -1;
+#endif
+}

--- a/pk/ecc/ecc_verify.c
+++ b/pk/ecc/ecc_verify.c
@@ -231,11 +231,13 @@ int main()
         );
     }
 
-    if (ret != 0) {
-        printf("Failure %d: %s\n", ret, wc_GetErrorString(ret));
-        return -1;
+    if (ret == 0) {
+        printf("Success\n");
     }
-    printf("Success\n");
+    else {
+        printf("Failure %d: %s\n", ret, wc_GetErrorString(ret));
+        ret = -1;
+    }
 
     return ret;
 #else

--- a/pk/ecc/ecc_verify.c
+++ b/pk/ecc/ecc_verify.c
@@ -1,0 +1,245 @@
+/* ecc_verify.c
+ *
+ * Copyright (C) 2006-2020 wolfSSL Inc.
+ *
+ * This file is part of wolfSSL. (formerly known as CyaSSL)
+ *
+ * wolfSSL is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * wolfSSL is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
+ */
+
+/* Example to demonstrate SHA-256 hashing and ECC Verify */
+/* 
+./configure CFLAGS="-DWOLFSSL_PUBLIC_MP" && make && sudo make install
+gcc -lwolfssl -o ecc_verify ecc_verify.c
+*/
+
+#ifndef WOLFSSL_USER_SETTINGS
+    #include <wolfssl/options.h>
+#endif
+#include <wolfssl/wolfcrypt/settings.h>
+#include <wolfssl/wolfcrypt/sha256.h>
+#include <wolfssl/wolfcrypt/ecc.h>
+#include <wolfssl/wolfcrypt/integer.h>
+#include <wolfssl/wolfcrypt/error-crypt.h>
+#include <wolfssl/wolfcrypt/logging.h>
+
+#include <stdint.h>
+#include <stdio.h>
+
+#define ECC_CURVE_SZ 32 /* SECP256R1 curve size in bytes */
+#define ECC_CURVE_ID ECC_SECP256R1
+
+/* Test Vectors */
+/* NIST P-256, SHA256 ECC Test Vector */
+static const uint8_t kMsg[] = {
+    0xba, 0xc1, 0x87, 0x53, 0x80, 0x9b, 0x27, 0xad, 0xa2, 0xb9, 0x4f, 0xd6, 0xac, 0x75, 0x39, 0xee, 
+    0x12, 0x95, 0xe2, 0xec, 0xf3, 0x80, 0x25, 0x8e, 0x89, 0x42, 0xb6, 0xf0, 0xeb, 0xbc, 0xe1, 0xaa, 
+    0xc9, 0x80, 0xfb, 0x0f, 0xe9, 0x36, 0xf9, 0x5d, 0xd1, 0x75, 0xc0, 0x27, 0x2d, 0x56, 0x07, 0x6a, 
+    0x50, 0xab, 0xd8, 0x26, 0x24, 0x8a, 0x6e, 0xab, 0xc9, 0xf1, 0x06, 0x6f, 0x65, 0x42, 0xe1, 0xdb, 
+    0xc7, 0x52, 0x1e, 0x3b, 0x0a, 0xfa, 0xc9, 0x74, 0x82, 0x39, 0x16, 0xfa, 0x2d, 0x8a, 0x23, 0x06, 
+    0x42, 0x97, 0x84, 0x8c, 0x3d, 0x93, 0x96, 0x84, 0x1d, 0xea, 0x53, 0x34, 0x3a, 0xf2, 0x5f, 0xbc, 
+    0xb1, 0x4d, 0x84, 0x85, 0xd5, 0x6c, 0xe3, 0x61, 0xce, 0x2a, 0x34, 0x47, 0x1c, 0x74, 0xeb, 0x7c, 
+    0x11, 0x20, 0x1d, 0x7f, 0x22, 0xc0, 0x9b, 0x8c, 0x90, 0xff, 0x32, 0x1a, 0xf0, 0xbd, 0xa0, 0xdc
+};
+static const uint8_t kPubKey[] = {
+    /* Qx */
+    0x65, 0x6f, 0xfd, 0x63, 0x85, 0x88, 0x89, 0x35, 
+    0x68, 0xe4, 0xa2, 0xdc, 0x72, 0x10, 0xdb, 0xdd, 
+    0x4a, 0x9e, 0xef, 0x51, 0xfe, 0x04, 0xfb, 0xf8, 
+    0x7c, 0xbb, 0x1a, 0x0d, 0x6f, 0xdc, 0x89, 0xec,
+    /* Qy */
+    0x37, 0x1e, 0x4e, 0x7f, 0x82, 0x75, 0x14, 0xb9, 
+    0x17, 0x38, 0x40, 0xe3, 0x18, 0x34, 0xd4, 0x55, 
+    0xc1, 0x44, 0x10, 0x30, 0xad, 0x77, 0x8a, 0x46, 
+    0x2d, 0xc2, 0xff, 0x94, 0x98, 0xad, 0x1e, 0xd8
+};
+static const uint8_t kSigRS[] = {
+    /* R */
+    0x60, 0x7e, 0x20, 0xf0, 0x62, 0xa2, 0x9b, 0xa7, 
+    0xf0, 0x93, 0x34, 0xc1, 0x14, 0xd4, 0x9f, 0x79, 
+    0x4d, 0xb3, 0xf4, 0xf4, 0x6a, 0x79, 0xb0, 0x1a, 
+    0x0b, 0x39, 0x20, 0x4d, 0x2d, 0x1f, 0x04, 0x30,
+    /* S */
+    0x9e, 0xb5, 0x1b, 0xfe, 0xa4, 0x7c, 0x14, 0x0d, 
+    0xfd, 0x71, 0x5f, 0xfd, 0x52, 0x3b, 0xdb, 0xe7, 
+    0x70, 0xa2, 0xd6, 0x29, 0x40, 0x74, 0xa9, 0xaa, 
+    0x4f, 0x36, 0x46, 0xea, 0x06, 0x01, 0xe9, 0xcf
+};
+
+
+#ifndef NO_SHA256
+/* perform hashing block by block */
+int crypto_sha256(const uint8_t *buf, uint32_t len, uint8_t *hash, 
+    uint32_t hashSz, uint32_t blkSz)
+{
+    int ret;
+    uint32_t i = 0, chunk;
+    wc_Sha256 sha256;
+    
+    /* validate arguments */
+    if ((buf == NULL && len > 0) || hash == NULL || 
+        hashSz < WC_SHA256_DIGEST_SIZE || blkSz == 0)
+    {
+        return BAD_FUNC_ARG;
+    }
+
+    /* Init Sha256 structure */
+    ret = wc_InitSha256(&sha256);
+    if (ret != 0) {
+        return ret;
+    }
+    while (i < len) {
+        chunk = blkSz;
+        if ((chunk + i) > len)
+            chunk = len - i;
+        /* Perform chunked update */
+        ret = wc_Sha256Update(&sha256, (buf + i), chunk);
+        if (ret != 0) {
+            break;
+        }
+        i += chunk;
+    }
+    if (ret == 0) {
+        /* Get final digest result */
+        ret = wc_Sha256Final(&sha256, hash);
+    }
+    return ret;
+}
+#endif
+
+
+#ifdef HAVE_ECC
+#ifdef HAVE_ECC_VERIFY
+/* perform verify of signature and hash using public key */
+/* key is public Qx + public Qy */
+/* sig is r + s */
+int crypto_ecc_verify(const uint8_t *key, uint32_t keySz,
+    const uint8_t *hash, uint32_t hashSz, const uint8_t *sig, uint32_t sigSz,
+    int curveSz, int curveId)
+{
+    int ret, verify_res = 0;
+    mp_int r, s;
+    ecc_key ecc;
+
+    /* validate arguments */
+    if (key == NULL || hash == NULL || sig == NULL || curveSz == 0 || 
+        hashSz == 0 || keySz < (curveSz*2) || sigSz < (curveSz*2))
+    {
+        return BAD_FUNC_ARG;
+    }
+
+    /* Setup the ECC key */
+    ret = wc_ecc_init(&ecc);
+    if (ret < 0) {
+        return ret;
+    }
+
+    /* Setup the signature r/s variables */
+    ret = mp_init(&r);
+    if (ret != MP_OKAY) {
+        wc_ecc_free(&ecc);
+        return ret;
+    }
+    ret = mp_init(&s);
+    if (ret != MP_OKAY) {
+        mp_clear(&r);
+        wc_ecc_free(&ecc);
+        return ret;
+    }
+
+    /* Import public key x/y */
+    ret = wc_ecc_import_unsigned(
+        &ecc, 
+        (byte*)key,             /* Public "x" Coordinate */
+        (byte*)(key + curveSz), /* Public "y" Coordinate */
+        NULL,                   /* Private "d" (optional) */
+        curveId                 /* ECC Curve Id */
+    );
+    /* Make sure it was a public key imported */
+    if (ret == 0 && ecc.type != ECC_PUBLICKEY) {
+        ret = ECC_BAD_ARG_E;
+    }
+
+    /* Import signature r/s */
+    if (ret == 0) {
+        ret = mp_read_unsigned_bin(&r, sig,  curveSz);
+    }
+    if (ret == 0) {
+        ret = mp_read_unsigned_bin(&s, sig + curveSz, curveSz);
+    }
+
+    /* Verify ECC Signature */
+    if (ret == 0) {
+        ret = wc_ecc_verify_hash_ex(
+            &r, &s,       /* r/s as mp_int */
+            hash, hashSz, /* computed hash digest */
+            &verify_res,  /* verification result 1=success */
+            &ecc
+        );
+    }
+    
+    /* check verify result */
+    if (ret == 0 && verify_res == 0) {
+        ret = SIG_VERIFY_E;
+    }
+
+    mp_clear(&r);
+    mp_clear(&s);
+    wc_ecc_free(&ecc);
+
+    return ret;
+}
+#endif /* HAVE_ECC_VERIFY */
+#endif /* HAVE_ECC */
+
+int main()
+{
+#if defined(HAVE_ECC) && defined(HAVE_ECC_VERIFY) && !defined(NO_SHA256)
+    int ret;
+    uint8_t hash[WC_SHA256_DIGEST_SIZE];
+    
+#ifdef DEBUG_WOLFSSL
+    wolfSSL_Debugging_ON();
+#endif
+
+    printf("Running NIST P-256,SHA-256 Verify Test Vector\n");
+
+    ret = crypto_sha256(
+        kMsg, sizeof(kMsg), /* input message */
+        hash, sizeof(hash), /* hash digest result */
+        32                  /* configurable block / chunk size */
+    );
+    if (ret == 0) {
+        ret = crypto_ecc_verify(
+            kPubKey, sizeof(kPubKey), /* public key point x/y */
+            hash, sizeof(hash),       /* computed hash digest */
+            kSigRS, sizeof(kSigRS),   /* signature r/s */
+            ECC_CURVE_SZ,             /* curve size in bytes */
+            ECC_CURVE_ID              /* curve id */
+        );
+    }
+
+    if (ret != 0) {
+        printf("Failure %d: %s\n", ret, wc_GetErrorString(ret));
+        return -1;
+    }
+    printf("Success\n");
+
+    return ret;
+#else
+    printf("wolfSSL requires ECC and SHA256\n");
+    return -1;
+#endif
+}


### PR DESCRIPTION
* Added improved ECC sign/verify examples using raw key/signature elements.
* Add ECC public key export example.
* Cleanup ecc_keys.c example.