### PR TITLE
Fixed linking order in ecc-sign-verify example

### DIFF
--- a/signature/ecc-sign-verify/Makefile
+++ b/signature/ecc-sign-verify/Makefile
@@ -10,7 +10,7 @@ all:ecc_sign_verify
 
 ecc_sign_verify:CFLAGS+=$(WOLFSSL_FLAGS)
 ecc_sign_verify:ecc_sign_verify.o
-	$(CC) -o $@ $(LIBS) $(WOLFSSL_LIB) $^ $(CFLAGS)
+	$(CC) -o $@ $^ $(LIBS) $(WOLFSSL_LIB) $(CFLAGS)
 
 .PHONY: clean all
 


### PR DESCRIPTION
Linking order is wrong in ecc-sign-verify makefile. If the .o is after $(LIBS) it fails to find wolfSSL symbols.

before the patch (gcc9.2.1, GNU/linux):

```
$ make
gcc -Wall -I/usr/local/include   -c -o ecc_sign_verify.o ecc_sign_verify.c
gcc -o ecc_sign_verify  -L/usr/local/lib -lwolfssl ecc_sign_verify.o -Wall -I/usr/local/include
/usr/bin/ld: ecc_sign_verify.o: in function `do_sig_ver_test':
ecc_sign_verify.c:(.text+0x2c0): undefined reference to `wolfSSL_Malloc'
/usr/bin/ld: ecc_sign_verify.c:(.text+0x2e6): undefined reference to `wolfCrypt_Init'
/usr/bin/ld: ecc_sign_verify.c:(.text+0x2f5): undefined reference to `wc_ecc_init'
/usr/bin/ld: ecc_sign_verify.c:(.text+0x32a): undefined reference to `wc_InitRng'
/usr/bin/ld: ecc_sign_verify.c:(.text+0x36b): undefined reference to `wc_ecc_make_key'
/usr/bin/ld: ecc_sign_verify.c:(.text+0x3c1): undefined reference to `wc_ecc_sign_hash'
/usr/bin/ld: ecc_sign_verify.c:(.text+0x416): undefined reference to `wc_ecc_verify_hash'
/usr/bin/ld: ecc_sign_verify.c:(.text+0x486): undefined reference to `wc_FreeRng'
/usr/bin/ld: ecc_sign_verify.c:(.text+0x495): undefined reference to `wc_ecc_free'
/usr/bin/ld: ecc_sign_verify.c:(.text+0x4b0): undefined reference to `wolfSSL_Free'
collect2: error: ld returned 1 exit status
make: *** [Makefile:13: ecc_sign_verify] Error 1
```

After the patch:

```
gcc -Wall -I/usr/local/include   -c -o ecc_sign_verify.o ecc_sign_verify.c
gcc -o ecc_sign_verify ecc_sign_verify.o  -L/usr/local/lib -lwolfssl -Wall -I/usr/local/include
```


