### PR TITLE
PKCS#11: Update samples to handle no user pin and ECC type

### DIFF
--- a/pkcs11/pkcs11_aescbc.c
+++ b/pkcs11/pkcs11_aescbc.c
@@ -87,16 +87,16 @@ int main(int argc, char* argv[])
     int slotId;
     int devId = 1;
 
-    if (argc != 5) {
+    if (argc != 4 && argc != 5) {
         fprintf(stderr,
-               "Usage: pkcs11_aescbc <libname> <slot> <tokenname> <userpin>\n");
+               "Usage: pkcs11_aescbc <libname> <slot> <tokenname> [userpin]\n");
         return 1;
     }
 
     library = argv[1];
     slot = argv[2];
     tokenName = argv[3];
-    userPin = argv[4];
+    userPin = (argc == 4) ? NULL : argv[4];
     slotId = atoi(slot);
 
 #if defined(DEBUG_WOLFSSL)
@@ -111,7 +111,7 @@ int main(int argc, char* argv[])
     }
     if (ret == 0) {
         ret = wc_Pkcs11Token_Init(&token, &dev, slotId, tokenName,
-                              (byte*)userPin, strlen(userPin));
+            (byte*)userPin, userPin == NULL ? 0 : strlen(userPin));
         if (ret != 0) {
             fprintf(stderr, "Failed to initialize PKCS#11 token\n");
             ret = 2;

--- a/pkcs11/pkcs11_aesgcm.c
+++ b/pkcs11/pkcs11_aesgcm.c
@@ -90,16 +90,16 @@ int main(int argc, char* argv[])
     int slotId;
     int devId = 1;
 
-    if (argc != 5) {
+    if (argc != 4 && argc != 5) {
         fprintf(stderr,
-               "Usage: pkcs11_aesgcm <libname> <slot> <tokenname> <userpin>\n");
+               "Usage: pkcs11_aesgcm <libname> <slot> <tokenname> [userpin]\n");
         return 1;
     }
 
     library = argv[1];
     slot = argv[2];
     tokenName = argv[3];
-    userPin = argv[4];
+    userPin = (argc == 4) ? NULL : argv[4];
     slotId = atoi(slot);
 
 #if defined(DEBUG_WOLFSSL)
@@ -114,7 +114,7 @@ int main(int argc, char* argv[])
     }
     if (ret == 0) {
         ret = wc_Pkcs11Token_Init(&token, &dev, slotId, tokenName,
-                              (byte*)userPin, strlen(userPin));
+            (byte*)userPin, userPin == NULL ? 0 : strlen(userPin));
         if (ret != 0) {
             fprintf(stderr, "Failed to initialize PKCS#11 token\n");
             ret = 2;

--- a/pkcs11/pkcs11_ecc.c
+++ b/pkcs11/pkcs11_ecc.c
@@ -163,16 +163,16 @@ int main(int argc, char* argv[])
     int slotId;
     int devId = 1;
 
-    if (argc != 5) {
+    if (argc != 4 && argc != 5) {
         fprintf(stderr,
-                "Usage: pkcs11_ecc <libname> <slot> <tokenname> <userpin>\n");
+                "Usage: pkcs11_ecc <libname> <slot> <tokenname> [userpin]\n");
         return 1;
     }
 
     library = argv[1];
     slot = argv[2];
     tokenName = argv[3];
-    userPin = argv[4];
+    userPin = (argc == 4) ? NULL : argv[4];
     slotId = atoi(slot);
 
 #if defined(DEBUG_WOLFSSL)
@@ -187,7 +187,7 @@ int main(int argc, char* argv[])
     }
     if (ret == 0) {
         ret = wc_Pkcs11Token_Init(&token, &dev, slotId, tokenName,
-                              (byte*)userPin, strlen(userPin));
+            (byte*)userPin, userPin == NULL ? 0 : strlen(userPin));
         if (ret != 0) {
             fprintf(stderr, "Failed to initialize PKCS#11 token\n");
             ret = 2;

--- a/pkcs11/pkcs11_genecc.c
+++ b/pkcs11/pkcs11_genecc.c
@@ -38,7 +38,8 @@ int gen_ec_keys(Pkcs11Token* token, ecc_key* key, unsigned char* id, int idLen,
     if (ret != 0)
         fprintf(stderr, "Failed to initialize EC key: %d\n", ret);
     if (ret == 0) {
-        ret = wc_ecc_make_key_ex(&rng, 32, key, ECC_CURVE_DEF);
+        ret = wc_ecc_make_key_ex2(&rng, 32, key, ECC_CURVE_DEF,
+                                  WC_ECC_FLAG_DEC_SIGN);
         if (ret != 0)
             fprintf(stderr, "Failed to generate EC key: %d\n", ret);
     }
@@ -98,16 +99,16 @@ int main(int argc, char* argv[])
     int slotId;
     int devId = 1;
 
-    if (argc != 5) {
+    if (argc != 4 && argc != 5) {
         fprintf(stderr,
-               "Usage: pkcs11_genecc <libname> <slot> <tokenname> <userpin>\n");
+               "Usage: pkcs11_genecc <libname> <slot> <tokenname> [userpin]\n");
         return 1;
     }
 
     library = argv[1];
     slot = argv[2];
     tokenName = argv[3];
-    userPin = argv[4];
+    userPin = (argc == 4) ? NULL : argv[4];
     slotId = atoi(slot);
 
 #if defined(DEBUG_WOLFSSL)
@@ -122,7 +123,7 @@ int main(int argc, char* argv[])
     }
     if (ret == 0) {
         ret = wc_Pkcs11Token_Init(&token, &dev, slotId, tokenName,
-                              (byte*)userPin, strlen(userPin));
+            (byte*)userPin, userPin == NULL ? 0 : strlen(userPin));
         if (ret != 0) {
             fprintf(stderr, "Failed to initialize PKCS#11 token\n");
             ret = 2;

--- a/pkcs11/pkcs11_hmac.c
+++ b/pkcs11/pkcs11_hmac.c
@@ -75,16 +75,16 @@ int main(int argc, char* argv[])
     int slotId;
     int devId = 1;
 
-    if (argc != 5) {
+    if (argc != 4 && argc != 5) {
         fprintf(stderr,
-               "Usage: pkcs11_aescbc <libname> <slot> <tokenname> <userpin>\n");
+               "Usage: pkcs11_aescbc <libname> <slot> <tokenname> [userpin]\n");
         return 1;
     }
 
     library = argv[1];
     slot = argv[2];
     tokenName = argv[3];
-    userPin = argv[4];
+    userPin = (argc == 4) ? NULL : argv[4];
     slotId = atoi(slot);
 
 #if defined(DEBUG_WOLFSSL)
@@ -99,7 +99,7 @@ int main(int argc, char* argv[])
     }
     if (ret == 0) {
         ret = wc_Pkcs11Token_Init(&token, &dev, slotId, tokenName,
-                              (byte*)userPin, strlen(userPin));
+            (byte*)userPin, userPin == NULL ? 0 : strlen(userPin));
         if (ret != 0) {
             fprintf(stderr, "Failed to initialize PKCS#11 token\n");
             ret = 2;

--- a/pkcs11/pkcs11_rand.c
+++ b/pkcs11/pkcs11_rand.c
@@ -60,16 +60,16 @@ int main(int argc, char* argv[])
     int devId = 1;
     WC_RNG rng;
 
-    if (argc != 5) {
+    if (argc != 4 && argc != 5) {
         fprintf(stderr,
-                "Usage: pkcs11_test <libname> <slot> <tokenname> <userpin>\n");
+                "Usage: pkcs11_test <libname> <slot> <tokenname> [userpin]\n");
         return 1;
     }
 
     library = argv[1];
     slot = argv[2];
     tokenName = argv[3];
-    userPin = argv[4];
+    userPin = (argc == 4) ? NULL : argv[4];
     slotId = atoi(slot);
 
 #if defined(DEBUG_WOLFSSL)
@@ -84,7 +84,7 @@ int main(int argc, char* argv[])
     }
     if (ret == 0) {
         ret = wc_Pkcs11Token_Init(&token, &dev, slotId, tokenName,
-                              (byte*)userPin, strlen(userPin));
+            (byte*)userPin, userPin == NULL ? 0 : strlen(userPin));
         if (ret != 0) {
             fprintf(stderr, "Failed to initialize PKCS#11 token\n");
             ret = 2;

--- a/pkcs11/pkcs11_rsa.c
+++ b/pkcs11/pkcs11_rsa.c
@@ -283,16 +283,16 @@ int main(int argc, char* argv[])
     int slotId;
     int devId = 1;
 
-    if (argc != 5) {
+    if (argc != 4 && argc != 5) {
         fprintf(stderr,
-                "Usage: pkcs11_rsa <libname> <slot> <tokenname> <userpin>\n");
+                "Usage: pkcs11_rsa <libname> <slot> <tokenname> [userpin]\n");
         return 1;
     }
 
     library = argv[1];
     slot = argv[2];
     tokenName = argv[3];
-    userPin = argv[4];
+    userPin = (argc == 4) ? NULL : argv[4];
     slotId = atoi(slot);
 
 #if defined(DEBUG_WOLFSSL)
@@ -307,7 +307,7 @@ int main(int argc, char* argv[])
     }
     else {
         ret = wc_Pkcs11Token_Init(&token, &dev, slotId, tokenName,
-                                  (byte*)userPin, strlen(userPin));
+            (byte*)userPin, userPin == NULL ? 0 : strlen(userPin));
         if (ret != 0) {
             fprintf(stderr, "Failed to initialize PKCS#11 token\n");
             ret = 2;

--- a/pkcs11/server-tls-pkcs11-ecc.c
+++ b/pkcs11/server-tls-pkcs11-ecc.c
@@ -229,16 +229,16 @@ int main(int argc, char* argv[])
     int slotId;
     int devId = 1;
 
-    if (argc != 5) {
+    if (argc != 4 && argc != 5) {
         fprintf(stderr,
-           "Usage: server_tls_pkcs11 <libname> <slot> <tokenname> <userpin>\n");
+           "Usage: server_tls_pkcs11 <libname> <slot> <tokenname> [userpin]\n");
         return 1;
     }
 
     library = argv[1];
     slot = argv[2];
     tokenName = argv[3];
-    userPin = argv[4];
+    userPin = (argc == 4) ? NULL : argv[4];
     slotId = atoi(slot);
 
 #if defined(DEBUG_WOLFSSL)
@@ -253,7 +253,7 @@ int main(int argc, char* argv[])
     }
     if (ret == 0) {
         ret = wc_Pkcs11Token_Init(&token, &dev, slotId, tokenName,
-                              (byte*)userPin, strlen(userPin));
+            (byte*)userPin, userPin == NULL ? 0 : strlen(userPin));
         if (ret != 0) {
             fprintf(stderr, "Failed to initialize PKCS#11 token\n");
             ret = 2;

--- a/pkcs11/server-tls-pkcs11.c
+++ b/pkcs11/server-tls-pkcs11.c
@@ -229,16 +229,16 @@ int main(int argc, char* argv[])
     int slotId;
     int devId = 1;
 
-    if (argc != 5) {
+    if (argc != 4 && argc != 5) {
         fprintf(stderr,
-           "Usage: server_tls_pkcs11 <libname> <slot> <tokenname> <userpin>\n");
+           "Usage: server_tls_pkcs11 <libname> <slot> <tokenname> [userpin]\n");
         return 1;
     }
 
     library = argv[1];
     slot = argv[2];
     tokenName = argv[3];
-    userPin = argv[4];
+    userPin = (argc == 4) ? NULL : argv[4];
     slotId = atoi(slot);
 
 #if defined(DEBUG_WOLFSSL)
@@ -253,7 +253,7 @@ int main(int argc, char* argv[])
     }
     if (ret == 0) {
         ret = wc_Pkcs11Token_Init(&token, &dev, slotId, tokenName,
-                              (byte*)userPin, strlen(userPin));
+            (byte*)userPin, userPin == NULL ? 0 : strlen(userPin));
         if (ret != 0) {
             fprintf(stderr, "Failed to initialize PKCS#11 token\n");
             ret = 2;


### PR DESCRIPTION
PKCS#11 devices allow generating an ECC key for Derivation or
Decrypt/Sign not both at once.