### PR TITLE
Fix -pwd arg length

### DIFF
--- a/wolfCLU/clu_src/crypto/clu_crypto_setup.c
+++ b/wolfCLU/clu_src/crypto/clu_crypto_setup.c
@@ -114,7 +114,7 @@ int wolfCLU_setup(int argc, char** argv, char action)
             inCheck = 1;
         }
 
-        ret = wolfCLU_checkForArg("-pwd", 3, argc, argv);
+        ret = wolfCLU_checkForArg("-pwd", 4, argc, argv);
         if (ret > 0) {
             /* password pwdKey */
             XMEMCPY(pwdKey, argv[ret+1], size);


### PR DESCRIPTION
fixes #235 

Verified decrypted file output of tests in `tests/testEncDec`.