### PR TITLE
Fix parsing of -pwd

### DIFF
--- a/wolfCLU/clu_src/crypto/clu_crypto_setup.c
+++ b/wolfCLU/clu_src/crypto/clu_crypto_setup.c
@@ -114,7 +114,7 @@ int wolfCLU_setup(int argc, char** argv, char action)
             inCheck = 1;
         }
 
-        ret = wolfCLU_checkForArg("-pwd", 3, argc, argv);
+        ret = wolfCLU_checkForArg("-pwd", 4, argc, argv);
         if (ret > 0) {
             /* password pwdKey */
             XMEMCPY(pwdKey, argv[ret+1], size);


### PR DESCRIPTION
The wolfCLU parser compared the wrong number of chars when checking for the `-pwd` option.

This fixes an issue reported by zd12084