### PR TITLE
Minor fix for TLS v1.3 server example and socket binding

### DIFF
--- a/tls/client-tls13.c
+++ b/tls/client-tls13.c
@@ -161,6 +161,10 @@ int main(int argc, char** argv)
     /*---------------------------------*/
     /* Start of security */
     /*---------------------------------*/
+#if 0
+    wolfSSL_Debugging_ON();
+#endif
+
     /* Initialize wolfSSL */
     if ((ret = wolfSSL_Init()) != WOLFSSL_SUCCESS) {
         fprintf(stderr, "ERROR: Failed to initialize the library\n");


### PR DESCRIPTION
Fix example server to set `SO_REUSEADDR` to prevent bind issues on improper shutdown of example. Do socket setup before the TLS setup.