### PR TITLE
Added an option to configure target host

### DIFF
--- a/ESP32/TLS13-wifi_station-client/main/Kconfig.projbuild
+++ b/ESP32/TLS13-wifi_station-client/main/Kconfig.projbuild
@@ -12,6 +12,12 @@ menu "Example Configuration"
         help
             WiFi password (WPA or WPA2) for the example to use.
 
+    config TLS_SMP_TARGET_HOST
+        string "Target Host"
+        default "127.0.0.1"
+        help
+            Set the target host IP address / domain
+
     config ESP_MAXIMUM_RETRY
         int "Maximum retry"
         default 5


### PR DESCRIPTION
And not in `station_example_main.c` which is less user-friendly. Needs two lines changed in `station_example_main.c` too.