### PR TITLE
wolfSSL_send_hrr_cookie is only available with WOLFSSL_SEND_HRR_COOKIE

### DIFF
--- a/dtls/server-dtls13-event.c
+++ b/dtls/server-dtls13-event.c
@@ -241,7 +241,7 @@ static int newPendingSSL(void)
         return 0;
     }
 
-#ifndef USE_DTLS12
+#if !defined(USE_DTLS12) && defined(WOLFSSL_SEND_HRR_COOKIE)
     {
         /* Applications should update this secret periodically */
         char *secret = "My secret";


### PR DESCRIPTION
Fix error when compiling with ./configure --enable-dtls --enable-dtls13 (without --enable-hrrcookie).