### PR TITLE
Tls client: fix bad comparison for non-blocking shutdown call.

### DIFF
--- a/tls/client-tls-nonblocking.c
+++ b/tls/client-tls-nonblocking.c
@@ -246,8 +246,7 @@ int main(int argc, char** argv)
         err = wolfSSL_get_error(ssl, 0);
         if (err == WOLFSSL_ERROR_WANT_READ)
             tcp_select(sockfd, SELECT_WAIT_SEC, 1);
-    } while (ret == WOLFSSL_ERROR_WANT_READ ||
-             ret == WOLFSSL_ERROR_WANT_WRITE);
+    } while (err == WOLFSSL_ERROR_WANT_READ || err == WOLFSSL_ERROR_WANT_WRITE);
     printf("Shutdown complete\n");
 
     ret = 0;


### PR DESCRIPTION
Dear WolfSSL developers,

After reading your example of the non-blocking TLS client, I think the loop's condition for the TLS shutdown is incorrect. The variable `err` must be compared, instead of `ret` directly.

I am providing this PR to fix this issue.

Cheers,
Jämes