### PR TITLE
Revert "Tls client: fix bad comparison for non-blocking shutdown call."

### DIFF
--- a/tls/client-tls-nonblocking.c
+++ b/tls/client-tls-nonblocking.c
@@ -246,7 +246,8 @@ int main(int argc, char** argv)
         err = wolfSSL_get_error(ssl, 0);
         if (err == WOLFSSL_ERROR_WANT_READ)
             tcp_select(sockfd, SELECT_WAIT_SEC, 1);
-    } while (err == WOLFSSL_ERROR_WANT_READ || err == WOLFSSL_ERROR_WANT_WRITE);
+    } while (ret == WOLFSSL_ERROR_WANT_READ ||
+             ret == WOLFSSL_ERROR_WANT_WRITE);
     printf("Shutdown complete\n");
 
     ret = 0;


### PR DESCRIPTION
This reverts commit 04db2c7cd9a3fe1fa5f2ce6a1119a8460bcd3a89.

We cannot accept without a contributor agreement. We will take this instead as a bug report and fix ourselves.