### PR TITLE
Minimize the size of object codes

### DIFF
--- a/signature/rsa_buffer/Makefile
+++ b/signature/rsa_buffer/Makefile
@@ -1,7 +1,7 @@
 # RSA Examples Makefile
 CC       = gcc
 LIB_PATH = /usr/local
-CFLAGS   = -Wall -I$(LIB_PATH)/include
+CFLAGS   = -Wall -I$(LIB_PATH)/include -include $(LIB_PATH)/include/wolfssl/options.h
 LIBS     = -L$(LIB_PATH)/lib -lm
 
 # option variables
@@ -14,8 +14,8 @@ OPTIMIZE        = -Os
 # Options
 #CFLAGS+=$(DEBUG_FLAGS)
 CFLAGS+=$(OPTIMIZE)
-#LIBS+=$(STATIC_LIB)
-LIBS+=$(DYN_LIB)
+LIBS+=$(STATIC_LIB)
+#LIBS+=$(DYN_LIB)
 
 # build targets
 SRC=$(wildcard *.c)

--- a/signature/rsa_buffer/dummy.c
+++ b/signature/rsa_buffer/dummy.c
@@ -1,0 +1,2 @@
+void *XMALLOC(int size) { return 0; }
+void XFREE(void *p) {}

--- a/signature/rsa_buffer/mk_minimum
+++ b/signature/rsa_buffer/mk_minimum
@@ -1,0 +1,25 @@
+WOLFROOT = ../../../wolfssl
+
+CFLAGS = -DWOLFSSL_USER_SETTINGS -I. -I$(WOLFROOT) -Os -g
+
+OBJ =\
+	$(WOLFROOT)/wolfcrypt/src/rsa.o\
+	$(WOLFROOT)/wolfcrypt/src/sp_int.o\
+	$(WOLFROOT)/wolfcrypt/src/sha256.o\
+	$(WOLFROOT)/wolfcrypt/src/hash.o\
+	$(WOLFROOT)/wolfcrypt/src/random.o\
+	$(WOLFROOT)/wolfcrypt/src/asn.o\
+	$(WOLFROOT)/wolfcrypt/src/wc_port.o\
+	$(WOLFROOT)/wolfcrypt/src/coding.o\
+
+all : verify sign
+verify: $(OBJ)
+	$(CC) $(CFLAGS) -o verify verify.c dummy.c $(OBJ)
+
+sign:  $(OBJ)
+	$(CC) $(CFLAGS) -o sign sign.c dummy.c $(OBJ)
+clean:
+	rm $(OBJ) verify sign
+
+size :
+	size $(OBJ)

--- a/signature/rsa_buffer/sign.c
+++ b/signature/rsa_buffer/sign.c
@@ -25,15 +25,17 @@
  * The output of this program can be used with "verify.c".
  */
 
+// #include <wolfssl/options.h>
+#include "user_settings.h"
 #include <stdio.h>
 
-#include <wolfssl/options.h>
 #include <wolfssl/wolfcrypt/rsa.h>
 #include <wolfssl/wolfcrypt/sha256.h>
 #include <wolfssl/wolfcrypt/asn.h>
 #include <wolfssl/wolfcrypt/asn_public.h>
 
 #include "rsa_priv_2048.h"
+
 
 /* Signature size is the length of the modulus of the RSA key */
 #define SIG_SZ              (2048 / 8)

--- a/signature/rsa_buffer/user_settings.h
+++ b/signature/rsa_buffer/user_settings.h
@@ -1,0 +1,66 @@
+
+#define NO_SIG_WRAPPER // -0
+
+#define WOLFCRYPT_ONLY
+#define XMALLOC_USER
+
+
+#define WOLFSSL_PUBLIC_MP
+
+#define NO_WRITEV // -0
+#define NO_SESSION_CACHE // -0
+#define NO_OLD_TLS // -0
+#define NO_RC4 // -0
+
+/* hash */
+#define NO_MD4
+#define NO_MD5
+#define NO_SHA
+
+/* rsa */
+#define WOLFSSL_RSA_VERIFY_INLINE
+#define WC_NO_RSA_OAEP
+#define WC_NO_HARDEN
+
+
+
+/* sp_int */
+#define NO_DH
+#define NO_DSA
+#define NO_DES3
+#define NO_AES
+#define WOLFSSL_SP_NO_DYN_STACK
+#define WOLFSSL_SP_SMALL
+
+
+/* asn */
+#define NO_ASN_TIME
+#define IGNORE_NAME_CONSTRAINTS
+// #define ASN_DUMP_OID // +212
+// #define RSA_DECODE_EXTRA // -0
+// #define WOLFSSL_CERT_GEN // +10000
+#define WOLFSSL_NO_ASN_STRICT // -200
+// #define WOLFSSL_NO_OCSP_OPTIONAL_CERTS // -0
+// #define WOLFSSL_NO_TRUSTED_CERTS_VERIFY +115
+// #define WOLFSSL_NO_OCSP_ISSUER_CHECK // -0
+// #define WOLFSSL_SMALL_CERT_VERIFY // +2000
+// #define WOLFSSL_NO_OCSP_DATE_CHECK // -0
+// #define WOLFSSL_FORCE_OCSP_NONCE_CHECK // -0
+// #define WOLFSSL_ASN_TEMPLATE // It can't be defined
+// #define NO_CERTS
+// #define WOLFSSL_ASN_TEMPLATE_TYPE_CHECK // -0
+// #define CRLDP_VALIDATE_DATA //-0
+// #define WOLFSSL_AKID_NAME // -0
+// #define WOLFSSL_CUSTOM_OID // -0
+// #define WOLFSSL_HAVE_ISSUER_NAMES // -0
+// #define WOLFSSL_SUBJ_DIR_ATTR // +500
+// #define WOLFSSL_SUBJ_INFO_ACC // + 500
+// #define WOLFSSL_FPKI // -0
+// #define WOLFSSL_CERT_NAME_ALL // -0
+
+/* wc_port */
+
+// #define WOLFSSL_NUCLEUS
+// #define WOLFSSL_USER_MUTEX
+// #define SINGLE_THREADED  // It may be bad macro
+// #define WOLFSSL_USER_FILESYSTEM

--- a/signature/rsa_buffer/verify.c
+++ b/signature/rsa_buffer/verify.c
@@ -25,7 +25,8 @@
  * "signature.h", used by this program, can be generated using "sign.c".
  */
 
-#include <wolfssl/options.h>
+// #include <wolfssl/options.h>
+#include "user_settings.h"
 #include <wolfssl/wolfcrypt/rsa.h>
 #include <wolfssl/wolfcrypt/sha256.h>
 #include <wolfssl/wolfcrypt/asn.h>
@@ -33,6 +34,7 @@
 
 #include "rsa_pub_2048.h"
 #include "signature.h"
+
 
 /* Maximum bound on digest algorithm encoding around digest */
 #define MAX_ENC_ALG_SZ      32

--- a/signature/rsa_vfy_only/Makefile
+++ b/signature/rsa_vfy_only/Makefile
@@ -1,7 +1,7 @@
 # RSA Examples Makefile
 CC       = gcc
 LIB_PATH = /usr/local
-CFLAGS   = -Wall -I$(LIB_PATH)/include
+CFLAGS   = -Wall -I$(LIB_PATH)/include -include $(LIB_PATH)/include/wolfssl/options.h
 LIBS     = -L$(LIB_PATH)/lib -lm
 
 # option variables

--- a/signature/rsa_vfy_only/README.md
+++ b/signature/rsa_vfy_only/README.md
@@ -1,9 +1,7 @@
 Configure and install wolfSSL with these options:
 
-./configure --disable-asn --disable-filesystem \
-    --enable-cryptonly --enable-sp=smallrsa2048 --enable-sp-math \
-    --disable-dh --disable-ecc --disable-sha224 --enable-rsavfy \
-    CFLAGS="-DWOLFSSL_PUBLIC_MP"
+./configure --enable-stable
+CFLAGS="-DWOLFSSL_PUBLIC_MP"
 make
 make install
 

--- a/signature/rsa_vfy_only/dummy.c
+++ b/signature/rsa_vfy_only/dummy.c
@@ -1,0 +1,2 @@
+void *XMALLOC(int size) { return 0; }
+void XFREE(void *p) {}

--- a/signature/rsa_vfy_only/mk_minimum
+++ b/signature/rsa_vfy_only/mk_minimum
@@ -1,0 +1,19 @@
+WOLFROOT = ../../../wolfssl
+
+CFLAGS = -DWOLFSSL_USER_SETTINGS -I. -I$(WOLFROOT) -Os -g
+
+OBJ =\
+	$(WOLFROOT)/wolfcrypt/src/rsa.o\
+	$(WOLFROOT)/wolfcrypt/src/sp_int.o\
+	$(WOLFROOT)/wolfcrypt/src/sha256.o\
+	$(WOLFROOT)/wolfcrypt/src/hash.o\
+	$(WOLFROOT)/wolfcrypt/src/random.o\
+
+all : verify
+verify: $(OBJ)
+	$(CC) $(CFLAGS) -o verify verify.c dummy.c $(OBJ)
+clean:
+	rm $(OBJ) verify
+
+size :
+	size $(OBJ)

--- a/signature/rsa_vfy_only/user_settings.h
+++ b/signature/rsa_vfy_only/user_settings.h
@@ -1,0 +1,44 @@
+
+#define NO_SIG_WRAPPER // -0
+
+#define WOLFCRYPT_ONLY
+#define XMALLOC_USER
+
+
+#define WOLFSSL_PUBLIC_MP
+
+#define NO_WRITEV // -0
+#define NO_SESSION_CACHE // -0
+#define NO_OLD_TLS // -0
+#define NO_RC4 // -0
+
+#define WC_NO_HARDEN
+
+/* hash */
+#define NO_MD4
+#define NO_MD5
+#define NO_SHA
+
+
+/* rsa */
+#define WOLFSSL_RSA_VERIFY_ONLY
+#define WOLFSSL_RSA_PUBLIC_ONLY
+#define WOLFSSL_RSA_VERIFY_INLINE
+#define WC_NO_RSA_OAEP
+
+/* math library */
+#define NO_ASN
+#define NO_DH
+#define NO_DSA
+#define NO_DES3
+#define NO_AES
+// #define WOLFSSL_SP_NO_256
+// #define WOLFSSL_SP_NO_3072
+// #define WOLFSSL_SP_NO_2048  // -0
+// #define WOLFSSL_SP_FAST_MODEXP
+#define WOLFSSL_SP_NO_DYN_STACK
+#define WOLFSSL_SP_SMALL
+// #define WOLFSSL_HAVE_SP_DH
+// #define WOLFSSL_HAVE_SP_RSA
+
+/* random */

--- a/signature/rsa_vfy_only/verify.c
+++ b/signature/rsa_vfy_only/verify.c
@@ -20,7 +20,6 @@
  */
 
 #include <stdio.h>
-#include <wolfssl/options.h>
 #include <wolfssl/wolfcrypt/settings.h>
 #include <wolfssl/wolfcrypt/rsa.h>
 #include <wolfssl/wolfcrypt/sha256.h>
@@ -170,7 +169,6 @@ int main(int argc, char* argv[])
         wc_FreeRsaKey(pRsaKey);
     if (pSha256 != NULL)
         wc_Sha256Free(pSha256);
-
     return ret == 0 ? 0 : 1;
 }
 


### PR DESCRIPTION
binary files:
	wolfssl-examples/signature/rsa_vfy_only/verify
	wolfssl-examples/signature/rsa_buffer/sign
	wolfssl-examples/signature/rsa_buffer/verify

To compile with make:
make -f mk_minimum