### PR TITLE
psa: use correct algorithm in key policy

### DIFF
--- a/psa/server-tls13-ecc-psa.c
+++ b/psa/server-tls13-ecc-psa.c
@@ -160,7 +160,7 @@ static int psa_private_key_provisioning(psa_key_id_t *key_id)
 
     psa_set_key_type(&key_attr, key_type);
     psa_set_key_usage_flags(&key_attr, PSA_KEY_USAGE_SIGN_HASH);
-    psa_set_key_algorithm(&key_attr, PSA_ALG_ECDSA_ANY);
+    psa_set_key_algorithm(&key_attr, PSA_ALG_ECDSA(PSA_ALG_ANY_HASH));
 
     status = psa_import_key(&key_attr, ecc_key_256,
                             sizeof(ecc_key_256), key_id);


### PR DESCRIPTION
otherwise it will not work with changes of c66a21c40a1800a51c8bdcb2871fee0804eecca8 (in wolfSSL) in which the hash algo is specified in `psa_sign_hash`:
```
+    /* Get correct hash algorithm that matches input hash length */
+    hash_algo = psa_map_hash_alg(input_length);
+
     status = psa_sign_hash(psa_ctx->private_key,
-                           PSA_ALG_ECDSA_ANY, input,
+                           PSA_ALG_ECDSA(hash_algo), input,
                            input_length, rs, sizeof(rs),

```

