### PR TITLE
ZD15937 - Add more detail on configuring wolfSSL for CAN-bus example in README

### DIFF
--- a/can-bus/README.md
+++ b/can-bus/README.md
@@ -6,16 +6,30 @@ This example implements a simple echo client and server that uses TLS over a CAN
 
 You need to have wolfSSL installed on your computer prior to building, this will need to be built with `WOLFSSL_ISOTP` defined to provide ISO-TP functionality.
 
-To generate the required SSL certificates use `./generate_ssl.sh`.
+In the `wolfssl` directory:
+```sh
+$ ./autogen.sh (this step might not be required if the configure script already exists)
+$ ./configure CFLAGS="-DWOLFSSL_ISOTP"
+$ make all
+$ sudo make install
+```
+
+Then in the `wolfssl-examples/can-bus` directory:
+```sh
+$ ./generate_ssl.sh
+$ make
+```
+
+The `client` and 'server` applications will be available in the `wolfssl-examples/can-bus' directory, as well as the required SSL certificates.
 
 ## Setting Up
 
 If you do not have a physical CAN bus between too machines you can use the virtual CAN bus which is a Linux kernel module. This behaves just like a real CAN bus with a similar bandwidth. To enable this run the following commands:
 
 ```sh
-sudo modprobe vcan
-sudo ip link add dev vcan0 type vcan
-sudo ip link set vcan0 up
+$ sudo modprobe vcan
+$ sudo ip link add dev vcan0 type vcan
+$ sudo ip link set vcan0 up
 ```
 
 ## Running
@@ -23,13 +37,13 @@ sudo ip link set vcan0 up
 On one console run the server, this should be executed first or the handshake will fail. This is executed using:
 
 ```sh
-server vcan0
+$ server vcan0
 ```
 
 Then in another terminal run the client:
 
 ```sh
-server vcan0
+$ client vcan0
 ```
 
 On both ends you will see:
@@ -60,6 +74,6 @@ Got message: Hello world! This is a CAN bus test!
 If you wish to disable the virtual CAN bus you can turn it off by doing:
 
 ```sh
-sudo ip link set vcan0 down
+$ sudo ip link set vcan0 down
 ```
 


### PR DESCRIPTION
Fixes: [zd15937](https://wolfssl.zendesk.com/agent/tickets/15937)

Add ./configure shell command to enable ISOTP support in wolfSSL for can-bus example.
