### PR TITLE
Update RT1060 example to support MIMXRT1060-EVKB board with SDK 2.13.1

### DIFF
--- a/RT1060/MIMXRT1062xxxxx_flexspi_nor.ld
+++ b/RT1060/MIMXRT1062xxxxx_flexspi_nor.ld
@@ -45,7 +45,7 @@ SECTIONS
     . = ALIGN(4);
   } > m_flash_config
 
-  ivt_begin= ORIGIN(m_flash_config) + LENGTH(m_flash_config);
+  ivt_begin = ORIGIN(m_flash_config) + LENGTH(m_flash_config);
 
   .ivt : AT(ivt_begin)
   {

--- a/RT1060/Makefile
+++ b/RT1060/Makefile
@@ -1,39 +1,17 @@
-SDK?=./SDK-2.8.2_EVK-MIMXRT1060
+#SDK?=./SDK_2_8_2_EVK-MIMXRT1060
+SDK?=./SDK_2_13_1_MIMXRT1060-EVKB
 WOLFSSL?=../../wolfssl
 
-CC=arm-none-eabi-gcc
-
+# Common settings and files
 ASMFLAGS=-D__STARTUP_CLEAR_BSS -D__STARTUP_INITIALIZE_NONCACHEDATA -mcpu=cortex-m7 -Wall -mfloat-abi=hard -mfpu=fpv5-d16 -mthumb -fno-common -ffunction-sections -fdata-sections -ffreestanding -fno-builtin -mapcs -std=gnu99
-CFLAGS=-DXIP_EXTERNAL_FLASH=1 -DXIP_BOOT_HEADER_ENABLE=1 -DCPU_MIMXRT1062DVL6A -DPRINTF_FLOAT_ENABLE=1 -DSCANF_FLOAT_ENABLE=1 -DPRINTF_ADVANCED_ENABLE=1 -DSCANF_ADVANCED_ENABLE=1 -DSERIAL_PORT_TYPE_UART=1 -Os -mcpu=cortex-m7 -Wall -mfloat-abi=hard -mfpu=fpv5-d16 -mthumb -MMD -MP -fno-common -ffunction-sections -fdata-sections -ffreestanding -fno-builtin -mapcs -std=gnu99 -DXPRINTF=PRINTF
-LDFLAGS= -mcpu=cortex-m7 -Wall -mfloat-abi=hard -mfpu=fpv5-d16 --specs=nosys.specs -fno-common -ffunction-sections -fdata-sections -ffreestanding -fno-builtin -mthumb -mapcs -Xlinker --gc-sections -Xlinker -static -Xlinker -z -Xlinker muldefs -Xlinker -Map=output.map -T MIMXRT1062xxxxx_flexspi_nor.ld -static -lm -lc -lnosys
-
 CFLAGS+=-I$(SDK)/devices/MIMXRT1062/utilities/debug_console/
 CFLAGS+=-I$(SDK)/components/serial_manager -I$(SDK)/components/uart/
 CFLAGS+=-I$(SDK) -I$(SDK)/devices/MIMXRT1062/drivers/ -I$(SDK)/devices/MIMXRT1062 -I$(SDK)/CMSIS/Include
 CFLAGS+=-I$(SDK)/devices/MIMXRT1062/utilities/str
 CFLAGS+=-I. -I$(WOLFSSL)
-
 CFLAGS+=-DWOLFSSL_USER_SETTINGS
-
-
-OBJS=common.o board.o pin_mux.o dcd.o clock_config.o $(SDK)/devices/MIMXRT1062/gcc/startup_MIMXRT1062.o $(SDK)/devices/MIMXRT1062/system_MIMXRT1062.o \
-     $(SDK)/devices/MIMXRT1062/drivers/fsl_clock.o \
-     $(SDK)/devices/MIMXRT1062/drivers/fsl_trng.o \
-     $(SDK)/devices/MIMXRT1062/drivers/fsl_common.o \
-     $(SDK)/devices/MIMXRT1062/utilities/debug_console/fsl_debug_console.o \
-     $(SDK)/devices/MIMXRT1062/utilities/str/fsl_str.o \
-     $(SDK)/components/uart/lpuart_adapter.o \
-     $(SDK)/components/serial_manager/serial_manager.o \
-     $(SDK)/components/lists/generic_list.o \
-     $(SDK)/components/serial_manager/serial_port_uart.o \
-     $(SDK)/devices/MIMXRT1062/drivers/fsl_lpuart.o \
-     $(SDK)/devices/MIMXRT1062/utilities/fsl_assert.o \
-     $(SDK)/devices/MIMXRT1062/drivers/fsl_gpio.o \
-     $(SDK)/devices/MIMXRT1062/xip/fsl_flexspi_nor_boot.o \
-     $(SDK)/boards/evkmimxrt1060/xip/evkmimxrt1060_flexspi_nor_config.o \
-     $(SDK)/devices/MIMXRT1062/utilities/fsl_sbrk.o
-
-OBJS+= \
+LDFLAGS=-mcpu=cortex-m7 -Wall -mfloat-abi=hard -mfpu=fpv5-d16 --specs=nosys.specs -fno-common -ffunction-sections -fdata-sections -ffreestanding -fno-builtin -mthumb -mapcs -Xlinker --gc-sections -Xlinker -static -Xlinker -z -Xlinker muldefs -Xlinker -Map=output.map -static -lm -lc -lnosys
+OBJS= \
      $(WOLFSSL)/wolfcrypt/src/wc_port.o \
      $(WOLFSSL)/wolfcrypt/src/wc_encrypt.o \
      $(WOLFSSL)/wolfcrypt/src/random.o \
@@ -59,6 +37,57 @@ OBJS+= \
      $(WOLFSSL)/wolfcrypt/src/wolfmath.o \
      $(WOLFSSL)/wolfcrypt/src/fe_low_mem.o
 
+# Board/SDK specific settings and files
+ifeq ($(SDK),./SDK_2_8_2_EVK-MIMXRT1060)
+
+CFLAGS+=-DXIP_EXTERNAL_FLASH=1 -DXIP_BOOT_HEADER_ENABLE=1 -DCPU_MIMXRT1062DVL6A -DPRINTF_FLOAT_ENABLE=1 -DSCANF_FLOAT_ENABLE=1 -DPRINTF_ADVANCED_ENABLE=1 -DSCANF_ADVANCED_ENABLE=1 -DSERIAL_PORT_TYPE_UART=1 -Os -mcpu=cortex-m7 -Wall -mfloat-abi=hard -mfpu=fpv5-d16 -mthumb -MMD -MP -fno-common -ffunction-sections -fdata-sections -ffreestanding -fno-builtin -mapcs -std=gnu99 -DXPRINTF=PRINTF
+LDFLAGS+=-T MIMXRT1062xxxxx_flexspi_nor.ld
+OBJS+=common.o board.o pin_mux.o dcd.o clock_config.o $(SDK)/devices/MIMXRT1062/gcc/startup_MIMXRT1062.o $(SDK)/devices/MIMXRT1062/system_MIMXRT1062.o \
+     $(SDK)/devices/MIMXRT1062/drivers/fsl_clock.o \
+     $(SDK)/devices/MIMXRT1062/drivers/fsl_trng.o \
+     $(SDK)/devices/MIMXRT1062/drivers/fsl_common.o \
+     $(SDK)/devices/MIMXRT1062/utilities/debug_console/fsl_debug_console.o \
+     $(SDK)/devices/MIMXRT1062/utilities/str/fsl_str.o \
+     $(SDK)/components/uart/lpuart_adapter.o \
+     $(SDK)/components/serial_manager/serial_manager.o \
+     $(SDK)/components/lists/generic_list.o \
+     $(SDK)/components/serial_manager/serial_port_uart.o \
+     $(SDK)/devices/MIMXRT1062/drivers/fsl_lpuart.o \
+     $(SDK)/devices/MIMXRT1062/utilities/fsl_assert.o \
+     $(SDK)/devices/MIMXRT1062/drivers/fsl_gpio.o \
+     $(SDK)/devices/MIMXRT1062/xip/fsl_flexspi_nor_boot.o \
+     $(SDK)/boards/evkmimxrt1060/xip/evkmimxrt1060_flexspi_nor_config.o \
+     $(SDK)/devices/MIMXRT1062/utilities/fsl_sbrk.o
+
+else ifeq ($(SDK),./SDK_2_13_1_MIMXRT1060-EVKB)
+
+CFLAGS+=-DXIP_EXTERNAL_FLASH=1 -DXIP_BOOT_HEADER_ENABLE=1 -DCPU_MIMXRT1062DVL6A -DWOLFSSL_IMXRT_DCP -DDCP_USE_DCACHE=0 -DWOLFSSL_USER_SETTINGS -DPRINTF_FLOAT_ENABLE=1 -DSCANF_FLOAT_ENABLE=1 -DPRINTF_ADVANCED_ENABLE=1 -DSCANF_ADVANCED_ENABLE=1 -DSERIAL_PORT_TYPE_UART=1 -DMCUXPRESSO_SDK -Os -mcpu=cortex-m7 -Wall -mfloat-abi=hard -mfpu=fpv5-d16 -mthumb -MMD -MP -fno-common -ffunction-sections -fdata-sections -ffreestanding -fno-builtin -mapcs -std=gnu99 -DXPRINTF=PRINTF
+CFLAGS+=-I$(SDK)/CMSIS/Core/Include
+CFLAGS+=-DDCP_USE_DCACHE=0
+LDFLAGS+=-T MIMXRT1062xxxxx_flexspi_nor.ld
+OBJS+=common.o board.o pin_mux.o dcd.o clock_config.o \
+     $(SDK)/boards/evkbmimxrt1060/xip/evkbmimxrt1060_flexspi_nor_config.o \
+     $(SDK)/components/uart/fsl_adapter_lpuart.o \
+     $(SDK)/components/serial_manager/fsl_component_serial_manager.o \
+     $(SDK)/components/lists/fsl_component_generic_list.o \
+     $(SDK)/components/serial_manager/fsl_component_serial_port_uart.o \
+     $(SDK)/devices/MIMXRT1062/gcc/startup_MIMXRT1062.o \
+     $(SDK)/devices/MIMXRT1062/xip/fsl_flexspi_nor_boot.o \
+     $(SDK)/devices/MIMXRT1062/system_MIMXRT1062.o \
+     $(SDK)/devices/MIMXRT1062/drivers/fsl_lpuart.o \
+     $(SDK)/devices/MIMXRT1062/drivers/fsl_clock.o \
+     $(SDK)/devices/MIMXRT1062/drivers/fsl_trng.o \
+     $(SDK)/devices/MIMXRT1062/drivers/fsl_common.o \
+     $(SDK)/devices/MIMXRT1062/drivers/fsl_gpio.o \
+     $(SDK)/devices/MIMXRT1062/drivers/fsl_cache.o \
+     $(SDK)/devices/MIMXRT1062/utilities/debug_console/fsl_debug_console.o \
+     $(SDK)/devices/MIMXRT1062/utilities/str/fsl_str.o \
+     $(SDK)/devices/MIMXRT1062/utilities/fsl_assert.o \
+     $(SDK)/devices/MIMXRT1062/utilities/fsl_sbrk.o
+
+endif
+
+# Other settings and files
 ifneq ($(DCP),0)
     OBJS+= \
      $(SDK)/devices/MIMXRT1062/drivers/fsl_dcp.o \

--- a/RT1060/README.md
+++ b/RT1060/README.md
@@ -1,26 +1,89 @@
-Building wolfCrypt benchmark on i.MX RT1060-EVK
+The examples for NXP i.MXRT1060 support the MMIMXRT1060-EVKB and the MMIMXRT1060-EVK boards.
 
-1. Go to  https://mcuxpresso.nxp.com and download the SDK archive for RT1060 - version 2.8.2
+Building and running the examples
+====
 
-2. Unpack the SDK archive into `./SDK-2.8.2_EVK-MIMXRT1060`
+Set up the NXP MCUXpresso SDK
+----
 
-3. Download latest wolfSSL (e.g. clone via `git clone git@github.com:wolfssl/wolfssl.git`) in the same directory as `wolfssl-examples`
+- Use the NXP _MCUXpresso SDK Builder_ available from NXP (https://mcuxpresso.nxp.com) to generate the SDK choosing:
 
-4. Ensure that a recent arm-gcc toolchain is installed and reachable from your path. A recent toolchain can be obtained from:
-    https://developer.arm.com/tools-and-software/open-source-software/developer-tools/gnu-toolchain/gnu-rm
+    - _Required Toolchains_: `GCC ARM Embedded`
 
-5. Clone this repository
+    For **MIMXRT1060-EVKB**:
+    - _Development Board_: `MIMXRT1060-EVKB (IMXRT1062xxxxA)`
+    - _Version_: `2.13.1`
 
-6. Enter the repository directory and run `make`
+    For **EVK-IMXRT1060**:
+    - _Development Board_: `EVK-MIMXRT1060 (IMXRT1062xxxxA)`
+    - _Version_: `2.8.2`
 
-7. Connect the RT1060-EVK to the computer via the OpenSDA USB port (L23)
+- Download the generated SDK archive and unpack it into:
 
-8. Copy either `wolfcrypt-test.bin` or `wolfcrypt-benchmark.bin` to the storage device associated to the RT1060-EVK
+    For **MIMXRT1060-EVKB**:
+    - `wolfssl-examples/RT1060/SDK_2_13_1_MIMXRT1060-EVKB`
 
-9. Open a terminal console emulator and connect it to the port associated to the RT1060-RVK (e.g. `/dev/ttyACM0`)
+    For **EVK-MIMXRT1060**:
+    - `wolfssl-examples/RT1060/SDK_2_8_2_EVK-MIMXRT1060`
 
-10. Reset the board to start the test or benchmark and read the result on the terminal console
+Set up ARM cross-compilation tools
+----
+
+- Ensure that a recent arm-gcc toolchain is installed and reachable via the `CC` environment variable.
+
+    - A recent toolchain can be obtained from ARM (https://developer.arm.com)
+
+    - Example: `CC=arm-none-eabi-gcc`
+
+Set up wolfSSL
+----
+
+- In the same directory as `wolfssl-examples` (i.e. the parent directory):
+
+```
+$ git clone git@github.com:wolfssl/wolfssl.git
+```
+
+Build wolfSSL
+----
+
+- In the `wolfssl-examples/RT1060` directory:
+
+    - For **MIMXRT1060-EVKB**:
+
+```
+$ SDK=SDK_2_13_1_MIMXRT1060-EVKB make
+```
+
+- For **EVK-MIMXRT106**:
 
 
-Benchmark results are also available in the file [results.md](results.md)
+```
+$ SDK=SDK_2_8_2_EVK-MIMXRT1060 make
+```
 
+The resulting binary files will be in `wolfssl-examples/RT1060`:
+
+- `wolfcrypt-test.bin` - wolfCrypt crytography test
+
+- `wolfcrypt-benchmark.bin` - wolfCrypt cryptography benchmark
+
+Download and run the built wolfSSL examples
+----
+
+- Connect the board to the host computer via the debug port
+
+- Copy a wolfSSL example binary file to the storage device associated with the board
+
+- Wait for the board to flash the image and reset
+
+- Open a terminal console emulator and connect it to the port associated with the board, e.g. `/dev/ttyACM0`
+
+- Reset the board.  The wolfSSL example output will display in the terminal console
+
+Notes
+====
+
+- EVK-MIMXRT1060 benchmark results are also available in the file [results.md](results.md)
+
+- MIMXRT1060-EVKB example developed using _arm-none-eabi-gcc (15:10.3-2021.07-4) 10.3.1 20210621 (release)_ on _Ubuntu 22.04LTS_ host

--- a/RT1060/SDK-2.8.2_EVK-MIMXRT1060/README.md
+++ b/RT1060/SDK-2.8.2_EVK-MIMXRT1060/README.md
@@ -1,3 +1,0 @@
-## SDK for i.MX RT1060
-
-Go to  https://mcuxpresso.nxp.com, download the SDK archive for RT1060 - version 2.8.2 and unpack it to this directory


### PR DESCRIPTION
**Description**
The i.MX RT1060 example is updated to run on the MIMXRT1060-EVKB using MCUXpresso SDK 2.13.1 on a Linux host with ARM GCC tools.  The example `README.md` document has been re-worked to account for the two targets.  The `Makefile` used to build the test images has been refactored some to account for the two targets.

**Testing**
Built on _Ubuntu 22.04 LTS_ host using _arm-none-eabi-gcc (15:10.3-2021.07-4) 10.3.1 20210621 (release)_ running the resulting test images on a _MIMXRT1060-EVKB_ board.
