### PR TITLE
Update cert (it was expired), remove redundent logic on OCSP_WANT_READ

### DIFF
--- a/ocsp/ocsp_nonblock/google.pem
+++ b/ocsp/ocsp_nonblock/google.pem
@@ -1,27 +1,185 @@
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number:
+            6e:c4:33:65:1a:7c:8b:9a:09:2c:57:96:f3:41:ce:45
+        Signature Algorithm: sha256WithRSAEncryption
+        Issuer: C = US, O = Google Trust Services LLC, CN = GTS CA 1C3
+        Validity
+            Not Before: May 22 08:17:23 2023 GMT
+            Not After : Aug 14 08:17:22 2023 GMT
+        Subject: CN = *.google.com
+        Subject Public Key Info:
+            Public Key Algorithm: rsaEncryption
+                RSA Public-Key: (2048 bit)
+                Modulus:
+                    00:98:82:84:87:bf:db:94:f3:49:26:59:36:7f:6e:
+                    d4:4d:8f:55:36:90:34:26:d9:3e:67:73:f6:74:ae:
+                    8f:79:31:ed:6a:ff:1b:c2:31:c5:90:91:de:b4:85:
+                    25:81:cf:3b:6f:81:a5:87:4c:31:3c:2e:48:ac:c3:
+                    a8:de:26:e2:12:dc:39:03:77:e2:65:1a:d0:3c:f5:
+                    f6:f6:d5:c1:3c:77:f9:97:7e:64:bf:dc:3e:42:e0:
+                    7c:54:f1:d0:17:18:f5:18:9e:2e:c0:52:b2:71:6f:
+                    02:a0:3c:c5:b3:50:c4:1e:50:8c:80:ca:47:d7:a4:
+                    4f:88:c5:1b:3c:4a:c4:fc:37:f4:7a:14:54:6d:de:
+                    02:29:82:2f:b9:55:8e:12:2e:86:be:fc:05:2f:eb:
+                    64:6d:cf:f0:96:72:aa:a4:f5:d1:45:cc:64:bd:bb:
+                    7c:a7:32:a1:bd:44:a2:dd:a9:54:de:7c:48:c6:24:
+                    af:87:ef:fd:b2:a2:f4:a6:6f:c6:b2:6d:3e:1d:69:
+                    49:a3:e2:cb:e9:55:d1:c7:0e:cc:08:27:a3:32:b7:
+                    81:1d:1d:b7:82:27:cb:98:4e:22:76:b1:98:df:96:
+                    cb:7b:92:dd:a4:80:df:80:95:cd:aa:0a:48:64:96:
+                    96:9f:0d:66:2e:b9:dc:5d:77:57:21:2d:18:0c:e3:
+                    34:63
+                Exponent: 65537 (0x10001)
+        X509v3 extensions:
+            X509v3 Key Usage: critical
+                Digital Signature, Key Encipherment
+            X509v3 Extended Key Usage: 
+                TLS Web Server Authentication
+            X509v3 Basic Constraints: critical
+                CA:FALSE
+            X509v3 Subject Key Identifier: 
+                C8:1F:B3:C6:09:07:DF:EA:18:D8:7B:24:02:59:1E:6D:06:77:9C:17
+            X509v3 Authority Key Identifier: 
+                keyid:8A:74:7F:AF:85:CD:EE:95:CD:3D:9C:D0:E2:46:14:F3:71:35:1D:27
+
+            Authority Information Access: 
+                OCSP - URI:http://ocsp.pki.goog/gts1c3
+                CA Issuers - URI:http://pki.goog/repo/certs/gts1c3.der
+
+            X509v3 Subject Alternative Name: 
+                DNS:*.google.com, DNS:*.appengine.google.com, DNS:*.bdn.dev, DNS:*.origin-test.bdn.dev, DNS:*.cloud.google.com, DNS:*.crowdsource.google.com, DNS:*.datacompute.google.com, DNS:*.google.ca, DNS:*.google.cl, DNS:*.google.co.in, DNS:*.google.co.jp, DNS:*.google.co.uk, DNS:*.google.com.ar, DNS:*.google.com.au, DNS:*.google.com.br, DNS:*.google.com.co, DNS:*.google.com.mx, DNS:*.google.com.tr, DNS:*.google.com.vn, DNS:*.google.de, DNS:*.google.es, DNS:*.google.fr, DNS:*.google.hu, DNS:*.google.it, DNS:*.google.nl, DNS:*.google.pl, DNS:*.google.pt, DNS:*.googleadapis.com, DNS:*.googleapis.cn, DNS:*.googlevideo.com, DNS:*.gstatic.cn, DNS:*.gstatic-cn.com, DNS:googlecnapps.cn, DNS:*.googlecnapps.cn, DNS:googleapps-cn.com, DNS:*.googleapps-cn.com, DNS:gkecnapps.cn, DNS:*.gkecnapps.cn, DNS:googledownloads.cn, DNS:*.googledownloads.cn, DNS:recaptcha.net.cn, DNS:*.recaptcha.net.cn, DNS:recaptcha-cn.net, DNS:*.recaptcha-cn.net, DNS:widevine.cn, DNS:*.widevine.cn, DNS:ampproject.org.cn, DNS:*.ampproject.org.cn, DNS:ampproject.net.cn, DNS:*.ampproject.net.cn, DNS:google-analytics-cn.com, DNS:*.google-analytics-cn.com, DNS:googleadservices-cn.com, DNS:*.googleadservices-cn.com, DNS:googlevads-cn.com, DNS:*.googlevads-cn.com, DNS:googleapis-cn.com, DNS:*.googleapis-cn.com, DNS:googleoptimize-cn.com, DNS:*.googleoptimize-cn.com, DNS:doubleclick-cn.net, DNS:*.doubleclick-cn.net, DNS:*.fls.doubleclick-cn.net, DNS:*.g.doubleclick-cn.net, DNS:doubleclick.cn, DNS:*.doubleclick.cn, DNS:*.fls.doubleclick.cn, DNS:*.g.doubleclick.cn, DNS:dartsearch-cn.net, DNS:*.dartsearch-cn.net, DNS:googletraveladservices-cn.com, DNS:*.googletraveladservices-cn.com, DNS:googletagservices-cn.com, DNS:*.googletagservices-cn.com, DNS:googletagmanager-cn.com, DNS:*.googletagmanager-cn.com, DNS:googlesyndication-cn.com, DNS:*.googlesyndication-cn.com, DNS:*.safeframe.googlesyndication-cn.com, DNS:app-measurement-cn.com, DNS:*.app-measurement-cn.com, DNS:gvt1-cn.com, DNS:*.gvt1-cn.com, DNS:gvt2-cn.com, DNS:*.gvt2-cn.com, DNS:2mdn-cn.net, DNS:*.2mdn-cn.net, DNS:googleflights-cn.net, DNS:*.googleflights-cn.net, DNS:admob-cn.com, DNS:*.admob-cn.com, DNS:googlesandbox-cn.com, DNS:*.googlesandbox-cn.com, DNS:*.safenup.googlesandbox-cn.com, DNS:*.gstatic.com, DNS:*.metric.gstatic.com, DNS:*.gvt1.com, DNS:*.gcpcdn.gvt1.com, DNS:*.gvt2.com, DNS:*.gcp.gvt2.com, DNS:*.url.google.com, DNS:*.youtube-nocookie.com, DNS:*.ytimg.com, DNS:android.com, DNS:*.android.com, DNS:*.flash.android.com, DNS:g.cn, DNS:*.g.cn, DNS:g.co, DNS:*.g.co, DNS:goo.gl, DNS:www.goo.gl, DNS:google-analytics.com, DNS:*.google-analytics.com, DNS:google.com, DNS:googlecommerce.com, DNS:*.googlecommerce.com, DNS:ggpht.cn, DNS:*.ggpht.cn, DNS:urchin.com, DNS:*.urchin.com, DNS:youtu.be, DNS:youtube.com, DNS:*.youtube.com, DNS:youtubeeducation.com, DNS:*.youtubeeducation.com, DNS:youtubekids.com, DNS:*.youtubekids.com, DNS:yt.be, DNS:*.yt.be, DNS:android.clients.google.com, DNS:developer.android.google.cn, DNS:developers.android.google.cn, DNS:source.android.google.cn
+            X509v3 Certificate Policies: 
+                Policy: 2.23.140.1.2.1
+                Policy: 1.3.6.1.4.1.11129.2.5.3
+
+            X509v3 CRL Distribution Points: 
+
+                Full Name:
+                  URI:http://crls.pki.goog/gts1c3/zdATt0Ex_Fk.crl
+
+            CT Precertificate SCTs: 
+                Signed Certificate Timestamp:
+                    Version   : v1 (0x0)
+                    Log ID    : 7A:32:8C:54:D8:B7:2D:B6:20:EA:38:E0:52:1E:E9:84:
+                                16:70:32:13:85:4D:3B:D2:2B:C1:3A:57:A3:52:EB:52
+                    Timestamp : May 22 09:17:27.757 2023 GMT
+                    Extensions: none
+                    Signature : ecdsa-with-SHA256
+                                30:44:02:20:36:1E:7A:EB:E1:C2:A9:05:D8:91:73:C7:
+                                04:28:0F:FC:E3:97:21:57:5B:0D:7F:70:BE:20:7B:37:
+                                AA:0B:46:2C:02:20:02:6E:15:18:08:D3:62:C5:6B:FC:
+                                38:58:EB:B3:7C:5F:80:0C:A2:24:52:B5:B5:43:B8:19:
+                                2A:09:6C:DF:12:16
+                Signed Certificate Timestamp:
+                    Version   : v1 (0x0)
+                    Log ID    : AD:F7:BE:FA:7C:FF:10:C8:8B:9D:3D:9C:1E:3E:18:6A:
+                                B4:67:29:5D:CF:B1:0C:24:CA:85:86:34:EB:DC:82:8A
+                    Timestamp : May 22 09:17:27.487 2023 GMT
+                    Extensions: none
+                    Signature : ecdsa-with-SHA256
+                                30:44:02:20:22:0A:20:A6:C7:D4:CF:ED:DF:55:66:5F:
+                                04:75:66:22:D4:11:4A:08:4D:86:67:39:19:D2:26:CC:
+                                2B:54:13:A8:02:20:3C:6B:78:BA:5F:83:E2:99:FA:78:
+                                9D:F2:29:6D:B3:19:0A:51:D9:A9:BB:40:E6:0E:D6:1A:
+                                07:45:6E:74:DA:14
+    Signature Algorithm: sha256WithRSAEncryption
+         75:4b:f0:ad:57:88:1c:db:53:b5:d2:61:14:a7:ca:83:dd:66:
+         cf:21:22:2e:3e:86:62:cb:2f:08:a2:cb:ad:d5:5a:d8:b1:e7:
+         80:8c:12:68:06:57:f0:18:a2:c9:78:07:8e:30:00:56:52:3b:
+         9d:25:c4:d5:61:50:60:8a:88:5d:9f:30:9c:65:cc:d8:2c:b7:
+         3d:be:09:91:d2:cb:be:12:57:a2:75:68:ba:19:87:cc:fe:36:
+         3c:c5:f9:f5:2c:7d:27:a2:90:02:62:b5:5a:2d:a6:be:f6:cc:
+         d1:7f:fd:f6:9d:f9:a0:63:5d:de:38:16:02:af:9d:55:fc:35:
+         e4:6b:10:6d:8d:8e:e6:80:53:72:30:07:de:4e:17:a4:04:7d:
+         38:fd:44:f3:df:65:a7:9b:b5:09:fd:24:73:fd:42:88:4c:fc:
+         ad:71:b1:0a:8f:5f:1c:cd:9e:f0:32:af:4b:f7:27:62:10:8d:
+         74:5e:64:15:3d:58:8a:d0:26:a4:b5:49:5e:f0:9d:ad:9a:ea:
+         98:cf:8d:df:a0:cc:a4:77:6d:66:70:76:6d:03:9c:94:21:af:
+         72:55:65:f4:e3:59:ac:10:70:b5:8f:6b:c9:f1:5b:59:3b:12:
+         33:56:c3:bf:dc:8f:36:6c:f7:f6:b2:b2:6f:a6:73:ca:22:91:
+         94:50:67:a8
 -----BEGIN CERTIFICATE-----
-MIIEhjCCA26gAwIBAgIQWwvxxxXoxEkSWJsftFiO7jANBgkqhkiG9w0BAQsFADBG
+MIIPBDCCDeygAwIBAgIQbsQzZRp8i5oJLFeW80HORTANBgkqhkiG9w0BAQsFADBG
 MQswCQYDVQQGEwJVUzEiMCAGA1UEChMZR29vZ2xlIFRydXN0IFNlcnZpY2VzIExM
-QzETMBEGA1UEAxMKR1RTIENBIDFDMzAeFw0yMjA1MDQxNzQwMDVaFw0yMjA3Mjcx
-NzQwMDRaMBkxFzAVBgNVBAMTDnd3dy5nb29nbGUuY29tMFkwEwYHKoZIzj0CAQYI
-KoZIzj0DAQcDQgAEy3kqjk9F7+Ap8XWjvvDnAUfiJXV6bHblqegicb6Krq3zUw8T
-KUQ8wxMtRoZXHv9DtZgC1ErW6qAPt0BWdzP7waOCAmYwggJiMA4GA1UdDwEB/wQE
-AwIHgDATBgNVHSUEDDAKBggrBgEFBQcDATAMBgNVHRMBAf8EAjAAMB0GA1UdDgQW
-BBSoMrJUWSIVHdDkqXgfi2VI5nQ2TjAfBgNVHSMEGDAWgBSKdH+vhc3ulc09nNDi
-RhTzcTUdJzBqBggrBgEFBQcBAQReMFwwJwYIKwYBBQUHMAGGG2h0dHA6Ly9vY3Nw
-LnBraS5nb29nL2d0czFjMzAxBggrBgEFBQcwAoYlaHR0cDovL3BraS5nb29nL3Jl
-cG8vY2VydHMvZ3RzMWMzLmRlcjAZBgNVHREEEjAQgg53d3cuZ29vZ2xlLmNvbTAh
-BgNVHSAEGjAYMAgGBmeBDAECATAMBgorBgEEAdZ5AgUDMDwGA1UdHwQ1MDMwMaAv
-oC2GK2h0dHA6Ly9jcmxzLnBraS5nb29nL2d0czFjMy9RT3ZKME4xc1QyQS5jcmww
-ggEDBgorBgEEAdZ5AgQCBIH0BIHxAO8AdQBByMqx3yJGShDGoToJQodeTjGLGwPr
-60vHaPCQYpYG9gAAAYCQX05XAAAEAwBGMEQCIA/HX1T2lssgnL8weEBFzPsILM4q
-/3iJ5FyXJgZZ9ZMQAiBi0HochB+UgZMpslJ72ei48hvzGErcXvUJUwXVx4x6ZwB2
-ACl5vvCeOTkh8FZzn2Old+W+V32cYAr4+U1dJlwlXceEAAABgJBfTiYAAAQDAEcw
-RQIhAIcwKuzq6j1VwM1F3P/3L0Un5LKUt4o52+KREIULHJ6yAiAIVxHlI0vTToyP
-N96UQkuM0FvPus2vGZLfIimVHrqrQzANBgkqhkiG9w0BAQsFAAOCAQEAw/wVl+C1
-0mjwVu3NCu9sbnX47TuPz2lwT/6aUOMmRQg5Z3I9qWwRs5TdwYS/RXjGbATG8STu
-Qmq5h4GRil5523D2OKmJ2ZBc033tk/aDJzf3bRQrFnzYNDIo2zW7rrdg0yUE2ytq
-30pP0so32wVtqAKZOdtgYyQs1WXEgOVouGkecgdKv2pMyWa6TVjMNnMxCwqq4MRG
-R5thr5l5tg20zvpGM7bE/VuYegTSqQyaF6arUpjpOX7xclfERZ1RUOh1EHHnH4gf
-l7eOUXh950nbb3bjp2bUF1CjsnveJI1UfqcUrp3Tuoh7ScT1gEiJ82qGsVtyq3AU
-FvKz0TJH0ipymA==
+QzETMBEGA1UEAxMKR1RTIENBIDFDMzAeFw0yMzA1MjIwODE3MjNaFw0yMzA4MTQw
+ODE3MjJaMBcxFTATBgNVBAMMDCouZ29vZ2xlLmNvbTCCASIwDQYJKoZIhvcNAQEB
+BQADggEPADCCAQoCggEBAJiChIe/25TzSSZZNn9u1E2PVTaQNCbZPmdz9nSuj3kx
+7Wr/G8IxxZCR3rSFJYHPO2+BpYdMMTwuSKzDqN4m4hLcOQN34mUa0Dz19vbVwTx3
++Zd+ZL/cPkLgfFTx0BcY9RieLsBSsnFvAqA8xbNQxB5QjIDKR9ekT4jFGzxKxPw3
+9HoUVG3eAimCL7lVjhIuhr78BS/rZG3P8JZyqqT10UXMZL27fKcyob1Eot2pVN58
+SMYkr4fv/bKi9KZvxrJtPh1pSaPiy+lV0ccOzAgnozK3gR0dt4Iny5hOInaxmN+W
+y3uS3aSA34CVzaoKSGSWlp8NZi653F13VyEtGAzjNGMCAwEAAaOCDBswggwXMA4G
+A1UdDwEB/wQEAwIFoDATBgNVHSUEDDAKBggrBgEFBQcDATAMBgNVHRMBAf8EAjAA
+MB0GA1UdDgQWBBTIH7PGCQff6hjYeyQCWR5tBnecFzAfBgNVHSMEGDAWgBSKdH+v
+hc3ulc09nNDiRhTzcTUdJzBqBggrBgEFBQcBAQReMFwwJwYIKwYBBQUHMAGGG2h0
+dHA6Ly9vY3NwLnBraS5nb29nL2d0czFjMzAxBggrBgEFBQcwAoYlaHR0cDovL3Br
+aS5nb29nL3JlcG8vY2VydHMvZ3RzMWMzLmRlcjCCCc0GA1UdEQSCCcQwggnAggwq
+Lmdvb2dsZS5jb22CFiouYXBwZW5naW5lLmdvb2dsZS5jb22CCSouYmRuLmRldoIV
+Ki5vcmlnaW4tdGVzdC5iZG4uZGV2ghIqLmNsb3VkLmdvb2dsZS5jb22CGCouY3Jv
+d2Rzb3VyY2UuZ29vZ2xlLmNvbYIYKi5kYXRhY29tcHV0ZS5nb29nbGUuY29tggsq
+Lmdvb2dsZS5jYYILKi5nb29nbGUuY2yCDiouZ29vZ2xlLmNvLmlugg4qLmdvb2ds
+ZS5jby5qcIIOKi5nb29nbGUuY28udWuCDyouZ29vZ2xlLmNvbS5hcoIPKi5nb29n
+bGUuY29tLmF1gg8qLmdvb2dsZS5jb20uYnKCDyouZ29vZ2xlLmNvbS5jb4IPKi5n
+b29nbGUuY29tLm14gg8qLmdvb2dsZS5jb20udHKCDyouZ29vZ2xlLmNvbS52boIL
+Ki5nb29nbGUuZGWCCyouZ29vZ2xlLmVzggsqLmdvb2dsZS5mcoILKi5nb29nbGUu
+aHWCCyouZ29vZ2xlLml0ggsqLmdvb2dsZS5ubIILKi5nb29nbGUucGyCCyouZ29v
+Z2xlLnB0ghIqLmdvb2dsZWFkYXBpcy5jb22CDyouZ29vZ2xlYXBpcy5jboIRKi5n
+b29nbGV2aWRlby5jb22CDCouZ3N0YXRpYy5jboIQKi5nc3RhdGljLWNuLmNvbYIP
+Z29vZ2xlY25hcHBzLmNughEqLmdvb2dsZWNuYXBwcy5jboIRZ29vZ2xlYXBwcy1j
+bi5jb22CEyouZ29vZ2xlYXBwcy1jbi5jb22CDGdrZWNuYXBwcy5jboIOKi5na2Vj
+bmFwcHMuY26CEmdvb2dsZWRvd25sb2Fkcy5jboIUKi5nb29nbGVkb3dubG9hZHMu
+Y26CEHJlY2FwdGNoYS5uZXQuY26CEioucmVjYXB0Y2hhLm5ldC5jboIQcmVjYXB0
+Y2hhLWNuLm5ldIISKi5yZWNhcHRjaGEtY24ubmV0ggt3aWRldmluZS5jboINKi53
+aWRldmluZS5jboIRYW1wcHJvamVjdC5vcmcuY26CEyouYW1wcHJvamVjdC5vcmcu
+Y26CEWFtcHByb2plY3QubmV0LmNughMqLmFtcHByb2plY3QubmV0LmNughdnb29n
+bGUtYW5hbHl0aWNzLWNuLmNvbYIZKi5nb29nbGUtYW5hbHl0aWNzLWNuLmNvbYIX
+Z29vZ2xlYWRzZXJ2aWNlcy1jbi5jb22CGSouZ29vZ2xlYWRzZXJ2aWNlcy1jbi5j
+b22CEWdvb2dsZXZhZHMtY24uY29tghMqLmdvb2dsZXZhZHMtY24uY29tghFnb29n
+bGVhcGlzLWNuLmNvbYITKi5nb29nbGVhcGlzLWNuLmNvbYIVZ29vZ2xlb3B0aW1p
+emUtY24uY29tghcqLmdvb2dsZW9wdGltaXplLWNuLmNvbYISZG91YmxlY2xpY2st
+Y24ubmV0ghQqLmRvdWJsZWNsaWNrLWNuLm5ldIIYKi5mbHMuZG91YmxlY2xpY2st
+Y24ubmV0ghYqLmcuZG91YmxlY2xpY2stY24ubmV0gg5kb3VibGVjbGljay5jboIQ
+Ki5kb3VibGVjbGljay5jboIUKi5mbHMuZG91YmxlY2xpY2suY26CEiouZy5kb3Vi
+bGVjbGljay5jboIRZGFydHNlYXJjaC1jbi5uZXSCEyouZGFydHNlYXJjaC1jbi5u
+ZXSCHWdvb2dsZXRyYXZlbGFkc2VydmljZXMtY24uY29tgh8qLmdvb2dsZXRyYXZl
+bGFkc2VydmljZXMtY24uY29tghhnb29nbGV0YWdzZXJ2aWNlcy1jbi5jb22CGiou
+Z29vZ2xldGFnc2VydmljZXMtY24uY29tghdnb29nbGV0YWdtYW5hZ2VyLWNuLmNv
+bYIZKi5nb29nbGV0YWdtYW5hZ2VyLWNuLmNvbYIYZ29vZ2xlc3luZGljYXRpb24t
+Y24uY29tghoqLmdvb2dsZXN5bmRpY2F0aW9uLWNuLmNvbYIkKi5zYWZlZnJhbWUu
+Z29vZ2xlc3luZGljYXRpb24tY24uY29tghZhcHAtbWVhc3VyZW1lbnQtY24uY29t
+ghgqLmFwcC1tZWFzdXJlbWVudC1jbi5jb22CC2d2dDEtY24uY29tgg0qLmd2dDEt
+Y24uY29tggtndnQyLWNuLmNvbYINKi5ndnQyLWNuLmNvbYILMm1kbi1jbi5uZXSC
+DSouMm1kbi1jbi5uZXSCFGdvb2dsZWZsaWdodHMtY24ubmV0ghYqLmdvb2dsZWZs
+aWdodHMtY24ubmV0ggxhZG1vYi1jbi5jb22CDiouYWRtb2ItY24uY29tghRnb29n
+bGVzYW5kYm94LWNuLmNvbYIWKi5nb29nbGVzYW5kYm94LWNuLmNvbYIeKi5zYWZl
+bnVwLmdvb2dsZXNhbmRib3gtY24uY29tgg0qLmdzdGF0aWMuY29tghQqLm1ldHJp
+Yy5nc3RhdGljLmNvbYIKKi5ndnQxLmNvbYIRKi5nY3BjZG4uZ3Z0MS5jb22CCiou
+Z3Z0Mi5jb22CDiouZ2NwLmd2dDIuY29tghAqLnVybC5nb29nbGUuY29tghYqLnlv
+dXR1YmUtbm9jb29raWUuY29tggsqLnl0aW1nLmNvbYILYW5kcm9pZC5jb22CDSou
+YW5kcm9pZC5jb22CEyouZmxhc2guYW5kcm9pZC5jb22CBGcuY26CBiouZy5jboIE
+Zy5jb4IGKi5nLmNvggZnb28uZ2yCCnd3dy5nb28uZ2yCFGdvb2dsZS1hbmFseXRp
+Y3MuY29tghYqLmdvb2dsZS1hbmFseXRpY3MuY29tggpnb29nbGUuY29tghJnb29n
+bGVjb21tZXJjZS5jb22CFCouZ29vZ2xlY29tbWVyY2UuY29tgghnZ3BodC5jboIK
+Ki5nZ3BodC5jboIKdXJjaGluLmNvbYIMKi51cmNoaW4uY29tggh5b3V0dS5iZYIL
+eW91dHViZS5jb22CDSoueW91dHViZS5jb22CFHlvdXR1YmVlZHVjYXRpb24uY29t
+ghYqLnlvdXR1YmVlZHVjYXRpb24uY29tgg95b3V0dWJla2lkcy5jb22CESoueW91
+dHViZWtpZHMuY29tggV5dC5iZYIHKi55dC5iZYIaYW5kcm9pZC5jbGllbnRzLmdv
+b2dsZS5jb22CG2RldmVsb3Blci5hbmRyb2lkLmdvb2dsZS5jboIcZGV2ZWxvcGVy
+cy5hbmRyb2lkLmdvb2dsZS5jboIYc291cmNlLmFuZHJvaWQuZ29vZ2xlLmNuMCEG
+A1UdIAQaMBgwCAYGZ4EMAQIBMAwGCisGAQQB1nkCBQMwPAYDVR0fBDUwMzAxoC+g
+LYYraHR0cDovL2NybHMucGtpLmdvb2cvZ3RzMWMzL3pkQVR0MEV4X0ZrLmNybDCC
+AQIGCisGAQQB1nkCBAIEgfMEgfAA7gB1AHoyjFTYty22IOo44FIe6YQWcDIThU07
+0ivBOlejUutSAAABiEK/000AAAQDAEYwRAIgNh566+HCqQXYkXPHBCgP/OOXIVdb
+DX9wviB7N6oLRiwCIAJuFRgI02LFa/w4WOuzfF+ADKIkUrW1Q7gZKgls3xIWAHUA
+rfe++nz/EMiLnT2cHj4YarRnKV3PsQwkyoWGNOvcgooAAAGIQr/SPwAABAMARjBE
+AiAiCiCmx9TP7d9VZl8EdWYi1BFKCE2GZzkZ0ibMK1QTqAIgPGt4ul+D4pn6eJ3y
+KW2zGQpR2am7QOYO1hoHRW502hQwDQYJKoZIhvcNAQELBQADggEBAHVL8K1XiBzb
+U7XSYRSnyoPdZs8hIi4+hmLLLwiiy63VWtix54CMEmgGV/AYosl4B44wAFZSO50l
+xNVhUGCKiF2fMJxlzNgstz2+CZHSy74SV6J1aLoZh8z+NjzF+fUsfSeikAJitVot
+pr72zNF//fad+aBjXd44FgKvnVX8NeRrEG2NjuaAU3IwB95OF6QEfTj9RPPfZaeb
+tQn9JHP9QohM/K1xsQqPXxzNnvAyr0v3J2IQjXReZBU9WIrQJqS1SV7wna2a6pjP
+jd+gzKR3bWZwdm0DnJQhr3JVZfTjWawQcLWPa8nxW1k7EjNWw7/cjzZs9/aysm+m
+c8oikZRQZ6g=
 -----END CERTIFICATE-----

--- a/ocsp/ocsp_nonblock/ocsp_nonblock.c
+++ b/ocsp/ocsp_nonblock/ocsp_nonblock.c
@@ -111,13 +111,11 @@ static int OcspLookupNonBlockCb(void* ctx, const char* url, int urlSz,
                     printf("OCSP ocsp request failed\n");
                 }
                 else {
-                    do {
-                        ret = wolfIO_HttpProcessResponseOcsp(sfd, ocspRespBuf, 
-                                        httpBuf, HTTP_SCRATCH_BUFFER_SIZE, NULL);
-                        nonBlockCnt++;
-                        if (ret == OCSP_WANT_READ)
-                            return WOLFSSL_CBIO_ERR_WANT_READ;
-                    } while (ret == OCSP_WANT_READ);
+                    ret = wolfIO_HttpProcessResponseOcsp(sfd, ocspRespBuf, 
+                                    httpBuf, HTTP_SCRATCH_BUFFER_SIZE, NULL);
+                    nonBlockCnt++;
+                    if (ret == OCSP_WANT_READ)
+                        return WOLFSSL_CBIO_ERR_WANT_READ;
                     printf("OCSP Response: ret %d, nonblock count %d\n", 
                         ret, nonBlockCnt);
                 }
@@ -149,9 +147,9 @@ int main(int argc, char** argv)
 {
     int ret;
     WOLFSSL_CERT_MANAGER* pCm;
-    char pem[2048];
+    char pem[14000];
     int pemSz = 0;
-    byte der[2000];
+    byte der[4000];
     int derSz = 0;
     FILE* file;
     const char* certFile = kGoogleCom;
@@ -191,6 +189,7 @@ int main(int argc, char** argv)
             file = fopen(certFile, "rb");
             if (file != NULL) {
                 pemSz = fread(pem, 1, sizeof(pem), file);
+                printf("pemSz = %d\n", pemSz);
                 fclose(file);
             }
 


### PR DESCRIPTION
A customer noticed some funny logic in the non-blocking example. If returning WOLFSSL_CBIO_ERR_WANT_READ from the do-while loop there is no reason to actually loop on OCSP_WANT_READ condition.

Also updated the google cert as it was outdated.