### PR TITLE
X9.146: Sign certificates with the right key

### DIFF
--- a/X9.146/README.md
+++ b/X9.146/README.md
@@ -30,7 +30,7 @@ Tested with these wolfSSL build options:
 
 ```sh
 ./autogen.sh  # If cloned from GitHub
-./configure --enable-dual-alg-certs --with-liboqs --enable-debug
+./configure --enable-experimental  --enable-dual-alg-certs --with-liboqs --enable-debug
 make
 sudo make install
 sudo ldconfig # required on some targets
@@ -350,16 +350,6 @@ examples/client/client -v 4 -A ../wolfssl-examples/X9.146/ca-rsa3072-falcon1-cer
 ```
 
 ## Generating a Certificate Chain and Adding Alternative keys and Signatures
-
-Tested with these wolfSSL build options:
-
-```sh
-./autogen.sh  # If cloned from GitHub
-./configure --enable-dual-alg-certs --enable-debug
-make
-sudo make install
-sudo ldconfig # required on some targets
-```
 
 In the directory where this README.md file is found, build the applications:
 

--- a/X9.146/README.md
+++ b/X9.146/README.md
@@ -107,7 +107,7 @@ openssl pkey  -in ../certs/dilithium_level2_server_key.der -inform der -out serv
 Then in wolfssl's source directory:
 
 ```
-examples/server/server -v 4 -c ../wolfssl-examples/X9.146/server-P256-dilithium2-cert.pem -k ../wolfssl-examples/X9.146/server-P256-key.pem --altPrivKey ../wolfssl-examples/X9.146/server-dilithium2-key-pq.pem
+examples/server/server -d -v 4 -c ../wolfssl-examples/X9.146/server-P256-dilithium2-cert.pem -k ../wolfssl-examples/X9.146/server-P256-key.pem --altPrivKey ../wolfssl-examples/X9.146/server-dilithium2-key-pq.pem
 
 examples/client/client -v 4 -A ../wolfssl-examples/X9.146/ca-P256-dilithium2-cert.pem
 ```
@@ -146,7 +146,7 @@ openssl pkey  -in ../certs/dilithium_level3_server_key.der -inform der -out serv
 Then in wolfssl's source directory:
 
 ```
-examples/server/server -v 4 -c ../wolfssl-examples/X9.146/server-P384-dilithium3-cert.pem -k ../wolfssl-examples/X9.146/server-P384-key.pem --altPrivKey ../wolfssl-examples/X9.146/server-dilithium3-key-pq.pem
+examples/server/server -d -v 4 -c ../wolfssl-examples/X9.146/server-P384-dilithium3-cert.pem -k ../wolfssl-examples/X9.146/server-P384-key.pem --altPrivKey ../wolfssl-examples/X9.146/server-dilithium3-key-pq.pem
 
 examples/client/client -v 4 -A ../wolfssl-examples/X9.146/ca-P384-dilithium3-cert.pem
 ```
@@ -185,7 +185,7 @@ openssl pkey  -in ../certs/dilithium_level5_server_key.der -inform der -out serv
 Then in wolfssl's source directory:
 
 ```
-examples/server/server -v 4 -c ../wolfssl-examples/X9.146/server-P521-dilithium5-cert.pem -k ../wolfssl-examples/X9.146/server-P521-key.pem --altPrivKey ../wolfssl-examples/X9.146/server-dilithium5-key-pq.pem
+examples/server/server -d -v 4 -c ../wolfssl-examples/X9.146/server-P521-dilithium5-cert.pem -k ../wolfssl-examples/X9.146/server-P521-key.pem --altPrivKey ../wolfssl-examples/X9.146/server-dilithium5-key-pq.pem
 
 examples/client/client -v 4 -A ../wolfssl-examples/X9.146/ca-P521-dilithium5-cert.pem
 ```
@@ -224,7 +224,7 @@ i
 Then in wolfssl's source directory:
 
 ```
-examples/server/server -v 4 -c ../wolfssl-examples/X9.146/server-P256-falcon1-cert.pem -k ../wolfssl-examples/X9.146/server-P256-key.pem --altPrivKey ../wolfssl-examples/X9.146/server-falcon1-key-pq.pem
+examples/server/server -d -v 4 -c ../wolfssl-examples/X9.146/server-P256-falcon1-cert.pem -k ../wolfssl-examples/X9.146/server-P256-key.pem --altPrivKey ../wolfssl-examples/X9.146/server-falcon1-key-pq.pem
 
 examples/client/client -v 4 -A ../wolfssl-examples/X9.146/ca-P256-falcon1-cert.pem
 ```
@@ -264,7 +264,7 @@ openssl pkey  -in ../certs/falcon_level5_server_key.der -inform der -out server-
 Then in wolfssl's source directory:
 
 ```
-examples/server/server -v 4 -c ../wolfssl-examples/X9.146/server-P521-falcon5-cert.pem -k ../wolfssl-examples/X9.146/server-P521-key.pem --altPrivKey ../wolfssl-examples/X9.146/server-falcon5-key-pq.pem
+examples/server/server -d -v 4 -c ../wolfssl-examples/X9.146/server-P521-falcon5-cert.pem -k ../wolfssl-examples/X9.146/server-P521-key.pem --altPrivKey ../wolfssl-examples/X9.146/server-falcon5-key-pq.pem
 
 examples/client/client -v 4 -A ../wolfssl-examples/X9.146/ca-P521-falcon5-cert.pem
 ```
@@ -305,7 +305,7 @@ openssl pkey  -in ../certs/dilithium_level2_server_key.der -inform der -out serv
 Then in wolfssl's source directory:
 
 ```
-examples/server/server -v 4 -c ../wolfssl-examples/X9.146/server-rsa3072-dilithium2-cert.pem -k ../wolfssl-examples/X9.146/server-rsa3072-key.pem --altPrivKey ../wolfssl-examples/X9.146/server-dilithium2-key-pq.pem
+examples/server/server -d -v 4 -c ../wolfssl-examples/X9.146/server-rsa3072-dilithium2-cert.pem -k ../wolfssl-examples/X9.146/server-rsa3072-key.pem --altPrivKey ../wolfssl-examples/X9.146/server-dilithium2-key-pq.pem
 
 examples/client/client -v 4 -A ../wolfssl-examples/X9.146/ca-rsa3072-dilithium2-cert.pem
 ```
@@ -344,7 +344,7 @@ openssl pkey  -in ../certs/falcon_level1_server_key.der -inform der -out server-
 Then in wolfssl's source directory:
 
 ```
-examples/server/server -v 4 -c ../wolfssl-examples/X9.146/server-rsa3072-falcon1-cert.pem -k ../wolfssl-examples/X9.146/server-rsa3072-key.pem --altPrivKey ../wolfssl-examples/X9.146/server-falcon1-key-pq.pem
+examples/server/server -d -v 4 -c ../wolfssl-examples/X9.146/server-rsa3072-falcon1-cert.pem -k ../wolfssl-examples/X9.146/server-rsa3072-key.pem --altPrivKey ../wolfssl-examples/X9.146/server-falcon1-key-pq.pem
 
 examples/client/client -v 4 -A ../wolfssl-examples/X9.146/ca-rsa3072-falcon1-cert.pem
 ```

--- a/X9.146/gen_dual_keysig_cert.c
+++ b/X9.146/gen_dual_keysig_cert.c
@@ -55,15 +55,14 @@ static int do_certgen(int argc, char** argv)
     int ret = 0;
 
     char caKeyFile[] = "./ca-key.der";
+    char altPrivFile[] = "./alt-ca-key.der";
 #ifdef GEN_ROOT_CERT
     char newCertOutput[] = "./ca-cert.der";
     char sapkiFile[] = "./alt-ca-pub-key.der";
-    char altPrivFile[] = "./alt-ca-key.der";
 #else
     char caCert[] = "./ca-cert.der";
     char newCertOutput[] = "./server-cert.der";
     char sapkiFile[] = "./alt-server-pub-key.der";
-    char altPrivFile[] = "./alt-server-key.der";
     char serverKeyFile[] = "./server-key.der";
 #endif
     FILE* file;

--- a/X9.146/gen_ecdsa_dilithium_dual_keysig_cert.c
+++ b/X9.146/gen_ecdsa_dilithium_dual_keysig_cert.c
@@ -79,25 +79,21 @@ static int do_certgen(int argc, char** argv)
     int ret = 0;
 
     char caKeyFile[] = "./ca-key.der";
+    char altPrivFile2[] = "../certs/dilithium_level2_ca_key.der";
+    char altPrivFile3[] = "../certs/dilithium_level3_ca_key.der";
+    char altPrivFile5[] = "../certs/dilithium_level5_ca_key.der";
 #ifdef GEN_ROOT_CERT
     char newCertOutput[] = "./ca-cert-pq.der";
     char sapkiFile2[] = "../certs/dilithium_level2_ca_pubkey.der";
-    char altPrivFile2[] = "../certs/dilithium_level2_ca_key.der";
     char sapkiFile3[] = "../certs/dilithium_level3_ca_pubkey.der";
-    char altPrivFile3[] = "../certs/dilithium_level3_ca_key.der";
     char sapkiFile5[] = "../certs/dilithium_level5_ca_pubkey.der";
-    char altPrivFile5[] = "../certs/dilithium_level5_ca_key.der";
 #else
     char caCert[] = "./ca-cert-pq.der";
     char newCertOutput[] = "./server-cert-pq.der";
     char serverKeyFile[] = "./server-key.der";
-
     char sapkiFile2[] = "../certs/dilithium_level2_server_pubkey.der";
-    char altPrivFile2[] = "../certs/dilithium_level2_server_key.der";
     char sapkiFile3[] = "../certs/dilithium_level3_server_pubkey.der";
-    char altPrivFile3[] = "../certs/dilithium_level3_server_key.der";
     char sapkiFile5[] = "../certs/dilithium_level5_server_pubkey.der";
-    char altPrivFile5[] = "../certs/dilithium_level5_server_key.der";
 #endif
     FILE* file;
     Cert newCert;

--- a/X9.146/gen_ecdsa_falcon_dual_keysig_cert.c
+++ b/X9.146/gen_ecdsa_falcon_dual_keysig_cert.c
@@ -79,22 +79,18 @@ static int do_certgen(int argc, char** argv)
     int ret = 0;
 
     char caKeyFile[] = "./ca-key.der";
+    char altPrivFile1[] = "../certs/falcon_level1_ca_key.der";
+    char altPrivFile5[] = "../certs/falcon_level5_ca_key.der";
 #ifdef GEN_ROOT_CERT
     char newCertOutput[] = "./ca-cert-pq.der";
-
     char sapkiFile1[] = "../certs/falcon_level1_ca_pubkey.der";
-    char altPrivFile1[] = "../certs/falcon_level1_ca_key.der";
     char sapkiFile5[] = "../certs/falcon_level5_ca_pubkey.der";
-    char altPrivFile5[] = "../certs/falcon_level5_ca_key.der";
 #else
     char caCert[] = "./ca-cert-pq.der";
     char newCertOutput[] = "./server-cert-pq.der";
     char serverKeyFile[] = "./server-key.der";
-
     char sapkiFile1[] = "../certs/falcon_level1_server_pubkey.der";
-    char altPrivFile1[] = "../certs/falcon_level1_server_key.der";
     char sapkiFile5[] = "../certs/falcon_level5_server_pubkey.der";
-    char altPrivFile5[] = "../certs/falcon_level5_server_key.der";
 #endif
     FILE* file;
     Cert newCert;

--- a/X9.146/gen_rsa_dilithium_dual_keysig_cert.c
+++ b/X9.146/gen_rsa_dilithium_dual_keysig_cert.c
@@ -72,16 +72,15 @@ static int do_certgen(int argc, char** argv)
     int ret = 0;
 
     char caKeyFile[] = "./ca-key.der";
+    char altPrivFile[] = "../certs/dilithium_level2_ca_key.der";
 #ifdef GEN_ROOT_CERT
     char newCertOutput[] = "./ca-cert-pq.der";
     char sapkiFile[] = "../certs/dilithium_level2_ca_pubkey.der";
-    char altPrivFile[] = "../certs/dilithium_level2_ca_key.der";
 #else
     char caCert[] = "./ca-cert-pq.der";
     char newCertOutput[] = "./server-cert-pq.der";
     char serverKeyFile[] = "./server-key.der";
     char sapkiFile[] = "../certs/dilithium_level2_server_pubkey.der";
-    char altPrivFile[] = "../certs/dilithium_level2_server_key.der";
 #endif
     FILE* file;
     Cert newCert;

--- a/X9.146/gen_rsa_falcon_dual_keysig_cert.c
+++ b/X9.146/gen_rsa_falcon_dual_keysig_cert.c
@@ -72,15 +72,14 @@ static int do_certgen(int argc, char** argv)
     int ret = 0;
 
     char caKeyFile[] = "./ca-key.der";
+    char altPrivFile[] = "../certs/falcon_level1_ca_key.der";
 #ifdef GEN_ROOT_CERT
     char newCertOutput[] = "./ca-cert-pq.der";
     char sapkiFile[] = "../certs/falcon_level1_ca_pubkey.der";
-    char altPrivFile[] = "../certs/falcon_level1_ca_key.der";
 #else
     char caCert[] = "./ca-cert-pq.der";
     char newCertOutput[] = "./server-cert-pq.der";
     char sapkiFile[] = "../certs/falcon_level1_server_pubkey.der";
-    char altPrivFile[] = "../certs/falcon_level1_server_key.der";
     char serverKeyFile[] = "./server-key.der";
 #endif
     FILE* file;


### PR DESCRIPTION
Hi all,

The hybrid certificate X9.146 examples use the wrong private key for creating the alternative signature of the server certificate. The alternative signature must be created with the issuer's private key (as already indicated in the code comments), not with the private key related to the actual certificate. In case of the server certificate generation, this was not the case (the server key is used).