### PR TITLE
Add wc_ecc_set_rng to ecdh_gen_secret

### DIFF
--- a/pk/ecdh_generate_secret/ecdh_gen_secret.c
+++ b/pk/ecdh_generate_secret/ecdh_gen_secret.c
@@ -86,9 +86,20 @@ int do_ecc(void)
     ret = wc_ecc_make_key(&rng, ECC_256_BIT_FIELD, &AliceKey);
     if (ret != 0)
         goto all_three;
+#ifdef ECC_TIMING_RESISTANT
+    ret = wc_ecc_set_rng(&AliceKey, &rng);
+    if (ret != 0)
+        goto all_three;
+#endif
+
     ret = wc_ecc_make_key(&rng, ECC_256_BIT_FIELD, &BobKey);
     if (ret != 0)
         goto all_three;
+#ifdef ECC_TIMING_RESISTANT
+    ret = wc_ecc_set_rng(&BobKey, &rng);
+    if (ret != 0)
+        goto all_three;
+#endif
 
     secretLen = ECC_256_BIT_FIELD; /* explicit set */
     ret = wc_ecc_shared_secret(&AliceKey, &BobKey, AliceSecret, &secretLen);


### PR DESCRIPTION
This fixes an issue reported in ZD18256

The config specified in the readme fails because the key RNG is not set.