### PR TITLE
Remove duplicated picotcp in README

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -106,6 +106,8 @@ android/wolfssljni-ndk-sample/proguard-project.txt
 /tls/client-tls-cryptocb
 /tls/server-tls-pkcallback
 /tls/client-tls-pkcallback
+/tls/server-tls-posthsauth
+/tls/client-tls-posthsauth
 /tls/server-tls-uart
 /tls/server-tls-verifycallback
 /tls/server-tls-writedup

--- a/README.md
+++ b/README.md
@@ -194,17 +194,6 @@ details.
 
 <br />
 
-#### picotcp (picoTCP Examples)
-
-This directory contains a TLS server created by using picoTCP via wolfSSL 
-custom callbacks.
-
-Please see the [picotcp/README.md](picotcp/README.md) for further usage and 
-details.
-
-
-<br />
-
 #### pk (Public-Key)
 
 This directory contains examples that demonstrate various wolfCrypt public-key 


### PR DESCRIPTION
README has duplicated pictocp explanation. Please see L#186-192 and L#197-203. This patch removes one of them.

Also, this patch adds `/tls/{server,client}-tls-posthsauth` to `.gitignore`, which is missing.