### PR TITLE
Clean up dtls resume example

### DIFF
--- a/dtls/client-dtls-resume.c
+++ b/dtls/client-dtls-resume.c
@@ -39,10 +39,12 @@
 #define MAXLINE   4096
 #define SERV_PORT 11111
 
-static int    new_udp_client_socket(WOLFSSL * ssl, const char * host);
-static int    talk_to_server(WOLFSSL * ssl, const char * msg);
+static int new_udp_client_socket(WOLFSSL * ssl, const char * host);
+static int talk_to_server(WOLFSSL * ssl, const char * msg);
 
-int main (int argc, char** argv)
+int
+main(int    argc,
+     char * argv[])
 {
     /* standard variables used in a dtls client*/
     int               sockfd = 0;
@@ -52,7 +54,6 @@ int main (int argc, char** argv)
     WOLFSSL *         ssl_res = NULL; /* The ssl for resuming connection. */
     WOLFSSL_CTX *     ctx = NULL;
     WOLFSSL_SESSION * session = NULL;
-    //const char *      msg = "client testing session resume";
     char              cert_array[] = "../certs/ca-cert.pem";
     char              buffer[80];
     char *            certs = cert_array;
@@ -258,7 +259,7 @@ talk_to_server(WOLFSSL *    ssl,
     }
 
     recv_msg[recv_len] = '\0';
-    fputs(recv_msg, stdout);
+    printf("info: server response: %s", recv_msg);
 
     return 0;
 }

--- a/dtls/server-dtls.c
+++ b/dtls/server-dtls.c
@@ -194,12 +194,12 @@ int main(int argc, char** argv)
                 int readErr = wolfSSL_get_error(ssl, 0);
                 if(readErr != SSL_ERROR_WANT_READ) {
                     printf("SSL_read failed.\n");
-                    goto error;
+                    break;
                 }
             }
             if (wolfSSL_write(ssl, ack, sizeof(ack)) < 0) {
                 printf("wolfSSL_write fail.\n");
-                goto error;
+                break;
             }
             else {
                 printf("Sending reply.\n");
@@ -217,7 +217,6 @@ int main(int argc, char** argv)
         printf("Client left cont to idle state\n");
     }
     
-error:
     if (cleanup == 1) {
         wolfSSL_set_fd(ssl, 0);
         wolfSSL_shutdown(ssl);


### PR DESCRIPTION
# Description

Give `client-dtls-resume.c` a refresh.

Fixes:
- https://github.com/wolfSSL/wolfssl-examples/issues/459

# Testing

With this running in server terminal window
```
$ ./server-dtls
```

run this in client terminal:
```
$ ./client-dtls-resume 127.0.0.1
info: opened socket: 3
info: saved session: 0xaaab05a87bb0
info: server response: I hear you fashizzle!
info: opened socket: 3
info: session ID reused; Successful resume
info: server response: I hear you fashizzle!
```