### PR TITLE
old wc naming convention fixes

### DIFF
--- a/crypto/3des/3des-file-encrypt.c
+++ b/crypto/3des/3des-file-encrypt.c
@@ -34,7 +34,7 @@
 /*
  * Makes a cryptographically secure key by stretching a user entered key
  */
-int GenerateKey(RNG* rng, byte* key, int size, byte* salt, int pad)
+int GenerateKey(WC_RNG* rng, byte* key, int size, byte* salt, int pad)
 {
     int ret;
 
@@ -47,7 +47,7 @@ int GenerateKey(RNG* rng, byte* key, int size, byte* salt, int pad)
 
     /* stretches key */
     ret = wc_PBKDF2(key, key, strlen((const char*)key), salt, SALT_SIZE, 4096,
-        size, SHA256);
+        size, WC_SHA256);
     if (ret != 0)
         return -1030;
 
@@ -59,7 +59,7 @@ int GenerateKey(RNG* rng, byte* key, int size, byte* salt, int pad)
  */
 int Des3Encrypt(Des3* des3, byte* key, int size, FILE* inFile, FILE* outFile)
 {
-    RNG     rng;
+    WC_RNG  rng;
     byte    iv[DES3_BLOCK_SIZE];
     byte*   input;
     byte*   output;
@@ -145,7 +145,7 @@ int Des3Encrypt(Des3* des3, byte* key, int size, FILE* inFile, FILE* outFile)
  */
 int Des3Decrypt(Des3* des3, byte* key, int size, FILE* inFile, FILE* outFile)
 {
-    RNG     rng;
+    WC_RNG  rng;
     byte    iv[DES3_BLOCK_SIZE];
     byte*   input;
     byte*   output;
@@ -183,7 +183,7 @@ int Des3Decrypt(Des3* des3, byte* key, int size, FILE* inFile, FILE* outFile)
 
     /* replicates old key if keys match */
     ret = wc_PBKDF2(key, key, strlen((const char*)key), salt, SALT_SIZE, 4096,
-        size, SHA256);
+        size, WC_SHA256);
     if (ret != 0)
         return -1050;
 

--- a/crypto/camellia/camellia-encrypt.c
+++ b/crypto/camellia/camellia-encrypt.c
@@ -33,7 +33,7 @@
 /*
  * Makes a cryptographically secure key by stretching a user entered key
  */
-int GenerateKey(RNG* rng, byte* key, int size, byte* salt, int pad)
+int GenerateKey(WC_RNG* rng, byte* key, int size, byte* salt, int pad)
 {
     int ret;
 
@@ -46,7 +46,7 @@ int GenerateKey(RNG* rng, byte* key, int size, byte* salt, int pad)
 
     /* stretches key */
     ret = wc_PBKDF2(key, key, strlen((const char*)key), salt, SALT_SIZE, 4096,
-        size, SHA256);
+        size, WC_SHA256);
     if (ret != 0)
         return -1030;
 
@@ -59,7 +59,7 @@ int GenerateKey(RNG* rng, byte* key, int size, byte* salt, int pad)
 int CamelliaEncrypt(Camellia* cam, byte* key, int size, FILE* inFile,
     FILE* outFile)
 {
-    RNG     rng;
+    WC_RNG  rng;
     byte    iv[CAMELLIA_BLOCK_SIZE];
     byte*   input;
     byte*   output;
@@ -144,7 +144,7 @@ int CamelliaEncrypt(Camellia* cam, byte* key, int size, FILE* inFile,
 int CamelliaDecrypt(Camellia* cam, byte* key, int size, FILE* inFile,
     FILE* outFile)
 {
-    RNG     rng;
+    WC_RNG  rng;
     byte    iv[CAMELLIA_BLOCK_SIZE];
     byte*   input;
     byte*   output;
@@ -182,7 +182,7 @@ int CamelliaDecrypt(Camellia* cam, byte* key, int size, FILE* inFile,
 
     /* replicates old key if keys match */
     ret = wc_PBKDF2(key, key, strlen((const char*)key), salt, SALT_SIZE, 4096,
-        size, SHA256);
+        size, WC_SHA256);
     if (ret != 0)
         return -1050;
 

--- a/signature/rsa_buffer/sign.c
+++ b/signature/rsa_buffer/sign.c
@@ -74,8 +74,8 @@ void print_buffer(char* name, unsigned char* data, word32 len)
 int main(int argc, char* argv[])
 {
     int            ret = 0;
-    Sha256         sha256;
-    Sha256*        pSha256 = NULL;
+    wc_Sha256      sha256;
+    wc_Sha256*     pSha256 = NULL;
     RsaKey         rsaKey;
     RsaKey*        pRsaKey = NULL;
 #ifdef WC_RSA_BLINDING

--- a/signature/rsa_buffer/verify.c
+++ b/signature/rsa_buffer/verify.c
@@ -47,8 +47,8 @@
 int main(int argc, char* argv[])
 {
     int            ret = 0;
-    Sha256         sha256;
-    Sha256*        pSha256 = NULL;
+    wc_Sha256      sha256;
+    wc_Sha256*     pSha256 = NULL;
     RsaKey         rsaKey;
     RsaKey*        pRsaKey = NULL;
     word32         idx;

--- a/signature/rsa_vfy_only/verify.c
+++ b/signature/rsa_vfy_only/verify.c
@@ -117,8 +117,8 @@ unsigned char rsa_sig_2048[] = {
 int main(int argc, char* argv[])
 {
     int            ret = 0;
-    Sha256         sha256;
-    Sha256*        pSha256 = NULL;
+    wc_Sha256      sha256;
+    wc_Sha256*     pSha256 = NULL;
     RsaKey         rsaKey;
     RsaKey*        pRsaKey = NULL;
     unsigned char* decSig = NULL;


### PR DESCRIPTION
In signature/rsa_buffer sign.c and verify.c contain old Sha256 naming convention. NO_OLD_WC_NAMES macro disables renaming of old naming conventions which is defined by default in newer wolfSSL versions. Fixes https://github.com/wolfSSL/wolfssl-examples/issues/510
Also fixed some other old naming conventions that i found in other files.