### PR TITLE
Fix autodetection of RP2350 (ARM mode).

### DIFF
--- a/RPi-Pico/CMakeLists.txt
+++ b/RPi-Pico/CMakeLists.txt
@@ -66,7 +66,7 @@ endif()
     target_compile_definitions(wolfssl PUBLIC
         WOLFSSL_USER_SETTINGS
     )
-    if (${PICO_PLATFORM} STREQUAL "rp2350")
+    if (${PICO_PLATFORM} STREQUAL "rp2350-arm-s")
         add_compile_definitions(wolfssl WOLFSSL_SP_ARM_CORTEX_M_ASM)
     elseif (${PICO_PLATFORM} STREQUAL "rp2350-riscv")
         add_compile_definitions(wolfSSL WOLFSSL_SP_RISCV32)


### PR DESCRIPTION
I was testing wolfSSL on RPi Pico and Pico 2 based on _RPi-Pico/CMakeLists.txt_ and  noticed ECC key creation routine (_wc_ecc_make_key()_) hanging on Pico 2, but working fine on Pico (1).

I traced it down to a hang in _sp_256_sqr_8()_, which seems to have caused (incorrectly) set ```WOLFSSL_SP_ARM_THUMB_ASM```.  (When compiling with ```WOLFSSL_SP_ARM_CORTEX_M_ASM``` there is no problem on Pico 2).

This updates platform detection to look for "rp2350-arm-s" instead "rp2350" in ${PICO_PLATFORM}.

