### PR TITLE
Fixed: Fix example pq/tls code to use current WolfSSL PQC macros

### DIFF
--- a/pq/tls/client-pq-tls13.c
+++ b/pq/tls/client-pq-tls13.c
@@ -36,7 +36,7 @@
 #include <wolfssl/wolfio.h>
 #include <wolfssl/wolfcrypt/error-crypt.h>
 
-#if defined(WOLFSSL_TLS13) && defined(WOLFSSL_HAVE_KYBER) && \
+#if defined(WOLFSSL_TLS13) && defined(WOLFSSL_WC_MLKEM) && \
     defined(HAVE_DILITHIUM)
 
 #define DEFAULT_PORT 11111
@@ -116,7 +116,7 @@ static int Tls13SecretCallback(WOLFSSL* ssl, int id, const unsigned char* secret
 int main(int argc, char** argv)
 {
     int ret = 0;
-#if defined(WOLFSSL_TLS13) && defined(WOLFSSL_HAVE_KYBER) && \
+#if defined(WOLFSSL_TLS13) && defined(WOLFSSL_WC_MLKEM) && \
     defined(HAVE_DILITHIUM)
     int                sockfd = SOCKET_INVALID;
     struct sockaddr_in servAddr;

--- a/pq/tls/server-pq-tls13.c
+++ b/pq/tls/server-pq-tls13.c
@@ -41,7 +41,7 @@
 #include <wolfssl/wolfio.h>
 #include <wolfssl/wolfcrypt/error-crypt.h>
 
-#if defined(WOLFSSL_TLS13) && defined(WOLFSSL_HAVE_KYBER) && \
+#if defined(WOLFSSL_TLS13) && defined(WOLFSSL_WC_MLKEM) && \
     defined(HAVE_DILITHIUM)
 
 #define DEFAULT_PORT 11111
@@ -145,7 +145,7 @@ int main(int argc, char** argv)
 {
     int ret = 0;
 
-#if defined(WOLFSSL_TLS13) && defined(WOLFSSL_HAVE_KYBER) && \
+#if defined(WOLFSSL_TLS13) && defined(WOLFSSL_WC_MLKEM) && \
     defined(HAVE_DILITHIUM)
 
     struct sockaddr_in servAddr;


### PR DESCRIPTION
- Replaced WOLFSSL_HAVE_KYBER with WOLFSSL_WC_MLKEM