### PR TITLE
Remove interim Arduino workflow REPO_OWNER redirect

### DIFF
--- a/.github/workflows/arduino.yml
+++ b/.github/workflows/arduino.yml
@@ -186,25 +186,12 @@ jobs:
         run: |
           # Clone the wolfssl to use for example build
 
-          # TODO remove after merge
-          REPO_OWNER=gojimmypi
-          # End TODO
-
           git clone --depth 1 https://github.com/$REPO_OWNER/wolfssl.git
 
           # Assign your PR branch for testing here:
           THIS_PR_BRANCH=""
 
           echo "REPO_OWNER=$REPO_OWNER"
-
-          # TODO remove after merge
-          # A user-specific branch assignment
-          if [[ "$REPO_OWNER" == "gojimmypi" ]]; then
-              THIS_PR_BRANCH="pr-arduino-testing"
-          else
-          	  echo "unexpected repo owner!"
-          fi
-          # END TODO
 
           # If a branch is assigned for current repo user, checkout
           if [ -z "$THIS_PR_BRANCH" ]; then


### PR DESCRIPTION
There was a chicken-egg problem with the concurrent develop of 4 part, 3-repo Arduino testing.

This PR removes the hard-coded `REPO_OWNER` redirect that used the wolfssl `pr-arduino-testing` branch during deployment.

See related:
- https://github.com/wolfSSL/wolfssl-examples/pull/519
- https://github.com/wolfSSL/wolfssl/pull/9091
- https://github.com/wolfSSL/Arduino-wolfSSL/pull/20

