### PR TITLE
TLS 1.3 certificate_authorities extension in ClientHello

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -115,8 +115,8 @@ android/wolfssljni-ndk-sample/proguard-project.txt
 /tls/server-tls-uart
 /tls/server-tls-verifycallback
 /tls/server-tls-writedup
-/tls/client-tls13-certauth-c2s
-/tls/server-tls13-certauth-c2s
+/tls/client-tls13-certauth-clienthello
+/tls/server-tls13-certauth-clienthello
 /tls/client-ech
 /tls/client-ech-local
 /tls/server-ech-local

--- a/tls/README.md
+++ b/tls/README.md
@@ -1413,6 +1413,35 @@ Execute them like so:
 ./server-tls-posthsauth 127.0.0.1
 ```
 
+## TLS Example with certificate_authorities extension in ClientHello message
+
+See `client-tls13-certauth-clienthello.c` and `server-tls13-certauth-clienthello.c`. These applications show how to use the TLS 1.3 [certificate_authorities](https://datatracker.ietf.org/doc/html/rfc8446#section-4.2.4) extension to let the client send the names of its supported certificate authorities inside the ClientHello message, so that the server can perform certificate selection based on them. This can be useful in scenarios where the server has multiple certificates issued by separate CAs.
+
+To use this example, you must enable full OpenSSL compatibility. Build and install wolfSSL like so:
+
+```
+$ ./autogen.sh
+$ ./configure --enable-opensslall
+$ make
+$ sudo make install
+```
+
+Then build the examples as follows:
+
+```
+make client-tls13-certauth-clienthello server-tls13-certauth-clienthello
+```
+
+Execute them like so:
+
+```
+./server-tls13-certauth-clienthello
+```
+
+```
+./client-tls13-certauth-clienthello 127.0.0.1
+```
+
 ## Support
 
 Please contact wolfSSL at support@wolfssl.com with any questions, bug fixes,

--- a/tls/client-tls13-certauth-clienthello.c
+++ b/tls/client-tls13-certauth-clienthello.c
@@ -1,4 +1,4 @@
-/* client-tls13-certauth-c2s.c
+/* client-tls13-certauth-clienthello.c
  *
  * Copyright (C) 2006-2025 wolfSSL Inc.
  *
@@ -58,8 +58,7 @@ int main(int argc, char** argv)
     !defined(WOLFSSL_NO_CA_NAMES) && !defined(NO_CERTS) && \
     defined(WOLFSSL_TLS13) && (defined(OPENSSL_EXTRA) || \
     defined(OPENSSL_EXTRA_X509_SMALL)) && (defined(OPENSSL_ALL) || \
-    defined(WOLFSSL_NGINX) || defined(HAVE_LIGHTY)) && \
-    LIBWOLFSSL_VERSION_HEX > 0x05008002
+    defined(WOLFSSL_NGINX) || defined(HAVE_LIGHTY))
 
     int                sockfd = SOCKET_INVALID;
     struct sockaddr_in servAddr;

--- a/tls/server-tls13-certauth-clienthello.c
+++ b/tls/server-tls13-certauth-clienthello.c
@@ -1,4 +1,4 @@
-/* server-tls13-certauth-c2s.c
+/* server-tls13-certauth-clienthello.c
  *
  * Copyright (C) 2006-2025 wolfSSL Inc.
  *
@@ -60,8 +60,7 @@
     !defined(WOLFSSL_NO_CA_NAMES) && !defined(NO_CERTS) && \
     defined(WOLFSSL_TLS13) && (defined(OPENSSL_EXTRA) || \
     defined(OPENSSL_EXTRA_X509_SMALL)) && (defined(OPENSSL_ALL) || \
-    defined(WOLFSSL_NGINX) || defined(HAVE_LIGHTY)) && \
-    LIBWOLFSSL_VERSION_HEX > 0x05008002
+    defined(WOLFSSL_NGINX) || defined(HAVE_LIGHTY))
 
 static int mSockfd = SOCKET_INVALID;
 static int mConnd = SOCKET_INVALID;
@@ -155,8 +154,7 @@ int main(int argc, char** argv)
     !defined(WOLFSSL_NO_CA_NAMES) && !defined(NO_CERTS) && \
     defined(WOLFSSL_TLS13) && (defined(OPENSSL_EXTRA) || \
     defined(OPENSSL_EXTRA_X509_SMALL)) && (defined(OPENSSL_ALL) || \
-    defined(WOLFSSL_NGINX) || defined(HAVE_LIGHTY)) && \
-    LIBWOLFSSL_VERSION_HEX > 0x05008002
+    defined(WOLFSSL_NGINX) || defined(HAVE_LIGHTY))
 
     struct sockaddr_in servAddr;
     struct sockaddr_in clientAddr;


### PR DESCRIPTION
This adds an example for the TLS 1.3 [certificate_authorities](https://datatracker.ietf.org/doc/html/rfc8446#section-4.2.4) extension in ClientHello.

This was newly implemented in wolfSSL/wolfSSL#9209. Should wait for that to be merged before this.