### PR TITLE
Parameterize compile-all-examples.sh for matrix use

### DIFF
--- a/.github/workflows/arduino-release.yml
+++ b/.github/workflows/arduino-release.yml
@@ -4,7 +4,7 @@ name: Arduino CI Build (2 of 4) Release Arduino wolfSSL for Local Examples
 #
 #      Known to fail on current 5.8.2 wolfSSL Arduino Release
 #
-# See ardduino.yml - Arduino CI Build (3 of 4) Latest wolfSSL for Local Examples
+# See arduino.yml - Arduino CI Build (3 of 4) Latest wolfSSL for Local Examples
 
 #
 # Test local Arduino examples with published Arduino wolfssl
@@ -44,7 +44,7 @@ name: Arduino CI Build (2 of 4) Release Arduino wolfSSL for Local Examples
 #
 # To test locally:
 # cd [your WOLFSSL_ROOT], e.g. cd /mnt/c/workspace/wolfssl-$USER
-# [optional checkout]     e.g. git checkout tags/v5.8.2-stable
+# [optional checkout]     e.g. git checkout tags/v5.8.4-stable
 # pushd ./IDE/ARDUINO
 # export ARDUINO_ROOT="$HOME/Arduino/libraries"
 # ./wolfssl-arduino.sh INSTALL
@@ -56,28 +56,73 @@ on:
   push:
     branches: [ '**', 'master', 'main', 'release/**' ]
     paths:
+      # Specific to this Arduino CI Build (2 of 4)
       - 'Arduino/**'
-      - '!Arduino/sketches/board_list.txt' # Not triggered on arduino.yml file. TODO remove this line after next Arduino wolfssl release
       - '.github/workflows/arduino-release.yml'
   pull_request:
     branches: [ '**' ]
     paths:
+      # Specific to this Arduino CI Build (2 of 4)
       - 'Arduino/**'
-      - '!Arduino/sketches/board_list.txt' # Not triggered on arduino.yml file. TODO remove this line after next Arduino wolfssl release
       - '.github/workflows/arduino-release.yml'
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  # Same branch push cancels other jobs. Other PR branches untouched
+
+  group: ${{ github.workflow }}-${{ github.ref_name }}
   cancel-in-progress: true
+
 # END OF COMMON SECTION
 
 jobs:
   build:
-    # if: github.repository_owner == 'wolfssl'
+    name: on FQBN (${{ matrix.fqbn }})
+    if: github.repository_owner == 'wolfssl'
     runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        fqbn:
+          # When editing this list, be sure to also edit file: board_list.txt
+          #   The compile-all-examples.sh optionally takes a FQBN parameter to
+          #   optionally compile all examples ONLY for the respective fully qualified board name.
+          # See https://github.com/wolfSSL/wolfssl-examples/blob/master/Arduino/sketches/board_list.txt
+
+          - arduino:avr:ethernet
+          - arduino:avr:leonardoeth
+          - arduino:avr:mega
+          - arduino:avr:nano
+          - arduino:avr:uno
+          - arduino:avr:yun
+          - arduino:samd:mkrwifi1010
+          - arduino:samd:mkr1000
+          - arduino:samd:mkrfox1200
+          - arduino:mbed_edge:edge_control
+          - arduino:mbed_nano:nanorp2040connect
+          - arduino:mbed_portenta:envie_m7
+          - arduino:mbed_portenta:portenta_x8
+          - arduino:renesas_uno:unor4wifi
+          - arduino:sam:arduino_due_x
+          - arduino:samd:arduino_zero_native
+          - arduino:samd:tian
+          - esp32:esp32:esp32
+          - esp32:esp32:esp32s2
+          - esp32:esp32:esp32s3
+          - esp32:esp32:esp32c3
+          - esp32:esp32:esp32c6
+          - esp32:esp32:esp32h2
+          - esp8266:esp8266:generic
+          - teensy:avr:teensy40
+
+          # Not yet supported, not in standard library
+          # - esp32:esp32:nano_nora
+
+          # End strategy matrix
     env:
       REPO_OWNER: ${{ github.repository_owner }}
+
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
@@ -86,7 +131,7 @@ jobs:
         run: |
           # Script to fetch and run install.sh from arduino/arduino-cli
 
-          # The install script will test to see if the recently installed apps in in the path
+          # The install script will test to see if the recently installed apps in the path
           # So set it up in advance:
           mkdir -p "${PWD}/bin"
           echo "${PWD}/bin" >> $GITHUB_PATH
@@ -97,7 +142,7 @@ jobs:
           # Ensures that BINDIR exists before the installer runs
           mkdir -p "$ROOT_BIN"
 
-          # Save as a lobal environment variable
+          # Save as a global environment variable
           echo "$ROOT_BIN" >> "$GITHUB_PATH"
 
           # Download and run install script from Arduino:
@@ -128,34 +173,53 @@ jobs:
             echo "Alternative install script not needed."
           fi
 
-      - name: Confirm Arduino CLI install
+      - name: Confirm Arduino CLI Install
         run: arduino-cli version
+
+      - name: Derive CORE_ID (vendor:arch from FQBN)
+        run: |
+          CORE_ID="$(echo '${{ matrix.fqbn }}' | cut -d: -f1-2)"
+          echo "CORE_ID=$CORE_ID" >> "$GITHUB_ENV"
 
       - name: Setup Arduino CLI
         run: |
           arduino-cli config init
-          arduino-cli core update-index
+
+          # wait 10 minutes for big downloads (or use 0 for no limit)
+          arduino-cli config set network.connection_timeout 600s
+
           arduino-cli config add board_manager.additional_urls https://www.pjrc.com/teensy/package_teensy_index.json
-          arduino-cli core update-index
           arduino-cli config add board_manager.additional_urls https://arduino.esp8266.com/stable/package_esp8266com_index.json
           arduino-cli core update-index
-          arduino-cli core install esp32:esp32            # ESP32
-          arduino-cli core install arduino:avr            # Arduino Uno, Mega, Nano
-          arduino-cli core install arduino:sam            # Arduino Due
-          arduino-cli core install arduino:samd           # Arduino Zero
-          arduino-cli core install teensy:avr             # PJRC Teensy
-          arduino-cli core install esp8266:esp8266        # ESP8266
-          arduino-cli core install arduino:mbed_nano      # nanorp2040connect
-          arduino-cli core install arduino:mbed_portenta  # portenta_h7_m7
-          arduino-cli core install arduino:mbed_edge
+
+          echo "CORE_ID: $CORE_ID"
+          arduino-cli core install "$CORE_ID"
+
+          # The above is instead of:
+          # arduino-cli core install esp32:esp32            # ESP32
+          # arduino-cli core install arduino:avr            # Arduino Uno, Mega, Nano
+          # arduino-cli core install arduino:sam            # Arduino Due
+          # arduino-cli core install arduino:samd           # Arduino Zero
+          # arduino-cli core install teensy:avr             # PJRC Teensy
+          # arduino-cli core install esp8266:esp8266        # ESP8266
+          # arduino-cli core install arduino:mbed_nano      # nanorp2040connect
+          # arduino-cli core install arduino:mbed_portenta  # portenta_h7_m7
+          # arduino-cli core install arduino:mbed_edge
+          # arduino-cli core install arduino:renesas_uno
+
+          # For reference:
+
+          # mbed nano not yet tested
           # sudo "/home/$USER/.arduino15/packages/arduino/hardware/mbed_nano/4.2.4/post_install.sh"
-          arduino-cli core install arduino:renesas_uno
+
+          # Always install networking (not part of FQBN matrix)
+          # The first one also creates directory: /home/runner/Arduino/libraries
           arduino-cli lib install "ArduinoJson"           # Example dependency
           arduino-cli lib install "WiFiNINA"              # ARDUINO_SAMD_NANO_33_IOT
           arduino-cli lib install "Ethernet"              # Install Ethernet library
           arduino-cli lib install "Bridge"                # Pseudo-network for things like arduino:samd:tian
 
-      - name: Set job environment variables
+      - name: Set Job Environment Variables
         run: |
           # Script to assign some common environment variables after everything is installed
 
@@ -181,6 +245,26 @@ jobs:
           # WOLFSSL_EXAMPLES_ROOT is the report root, not example location
           echo "WOLFSSL_EXAMPLES_ROOT = $WOLFSSL_EXAMPLES_ROOT"
 
+      - name: Cache Arduino Packages
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.arduino15
+            ~/.cache/arduino
+            ~/.arduino15/staging
+
+            # Arduino libraries
+            # Specific to Arduino CI Build (2 of 4) Arduinbo Release wolfSSL for Local Examples
+            # Include all libraries, as the latest Arduino-wolfSSL will only change upon release.
+            ~/Arduino/libraries
+            # Ensure wolfssl is not cached, we're always using the latest. See separate cache.
+            !~/Arduino/libraries/wolfssl
+          key: arduino-${{ runner.os }}-${{ env.CORE_ID }}-${{ hashFiles('Arduino/sketches/board_list.txt') }}
+
+          restore-keys: |
+               arduino-${{ runner.os }}-${{ env.CORE_ID }}-
+               arduino-${{ runner.os }}-
+
       - name: Show wolfssl-examples
         run: |
           # The examples are local in this wolfssl-example repo, but should have been copied to library, above
@@ -188,6 +272,7 @@ jobs:
 
           # end Show wolfssl-examples
 
+      # Specific to Arduino CI Build (3 of 4) Arduinbo Release wolfSSL for Local Examples
           # - name: Shallow clone wolfssl
           #
           #         not used here, we'll install with arduino-cli in next step
@@ -220,22 +305,25 @@ jobs:
           echo "Current directory     = $PWD"
           echo "ARDUINO_ROOT          = $ARDUINO_ROOT"
           echo "WOLFSSL_EXAMPLES_ROOT = $WOLFSSL_EXAMPLES_ROOT"
+          echo "FQBN                  = ${{ matrix.fqbn }}"
 
+          echo "Change directory to Arduino examples..."
           pushd ./Arduino/sketches
             chmod +x ./compile-all-examples.sh
 
             # The script expects all the examples to be in the current directory.
-            # So copy from local directory to newly instlled wolfssl arduino library to compile there.
+            # So copy from local directory to newly installed wolfssl arduino library to compile there.
             cp ./compile-all-examples.sh "$ARDUINO_ROOT/wolfssl/examples/compile-all-examples.sh"
             cp ./board_list.txt          "$ARDUINO_ROOT/wolfssl/examples/board_list.txt"
 
             # TODO Use standard board_list.txt after next release of wolfSSL
+            # Remove this line and edit parameter to /compile-all-examples.sh board_list.txt
             cp ./board_list_v5.8.2.txt   "$ARDUINO_ROOT/wolfssl/examples/board_list_v5.8.2.txt"
 
             # Compile the Arduino library examples in-place
             pushd "$ARDUINO_ROOT/wolfssl/examples/"
               echo "PWD=$PWD"
-              ./compile-all-examples.sh board_list_v5.8.2.txt
+              ./compile-all-examples.sh board_list_v5.8.2.txt "${{ matrix.fqbn }}"
             popd
           popd
 

--- a/.github/workflows/arduino.yml
+++ b/.github/workflows/arduino.yml
@@ -38,7 +38,7 @@ name: Arduino CI Build (3 of 4) Latest wolfSSL for Local Examples
 #
 # To test locally:
 # cd [your WOLFSSL_ROOT], e.g. cd /mnt/c/workspace/wolfssl-$USER
-# [optional checkout]     e.g. git checkout tags/v5.8.2-stable
+# [optional checkout]     e.g. git checkout tags/v5.8.4-stable
 # pushd ./IDE/ARDUINO
 # export ARDUINO_ROOT="$HOME/Arduino/libraries"
 # ./wolfssl-arduino.sh INSTALL
@@ -50,28 +50,73 @@ on:
   push:
     branches: [ '**', 'master', 'main', 'release/**' ]
     paths:
+      # Specific to this Arduino CI Build (3 of 4)
       - 'Arduino/**'
-      - '!Arduino/sketches/board_list_v5.8.2.txt' # Not triggered on arduino-release.yml file. TODO remove this line after next Arduino wolfssl release
       - '.github/workflows/arduino.yml'
   pull_request:
     branches: [ '**' ]
     paths:
+      # Specific to this Arduino CI Build (3 of 4)
       - 'Arduino/**'
-      - '!Arduino/sketches/board_list_v5.8.2.txt' # Not triggered on arduino-release.yml file. TODO remove this line after next Arduino wolfssl release
       - '.github/workflows/arduino.yml'
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  # Same branch push cancels other jobs. Other PR branches untouched
+
+  group: ${{ github.workflow }}-${{ github.ref_name }}
   cancel-in-progress: true
+
 # END OF COMMON SECTION
 
 jobs:
   build:
-    # if: github.repository_owner == 'wolfssl'
+    name: on FQBN (${{ matrix.fqbn }})
+    if: github.repository_owner == 'wolfssl'
     runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        fqbn:
+          # When editing this list, be sure to also edit file: board_list.txt
+          #   The compile-all-examples.sh optionally takes a FQBN parameter to
+          #   optionally compile all examples ONLY for the respective fully qualified board name.
+          # See https://github.com/wolfSSL/wolfssl-examples/blob/master/Arduino/sketches/board_list.txt
+
+          - arduino:avr:ethernet
+          - arduino:avr:leonardoeth
+          - arduino:avr:mega
+          - arduino:avr:nano
+          - arduino:avr:uno
+          - arduino:avr:yun
+          - arduino:samd:mkrwifi1010
+          - arduino:samd:mkr1000
+          - arduino:samd:mkrfox1200
+          - arduino:mbed_edge:edge_control
+          - arduino:mbed_nano:nanorp2040connect
+          - arduino:mbed_portenta:envie_m7
+          - arduino:mbed_portenta:portenta_x8
+          - arduino:renesas_uno:unor4wifi
+          - arduino:sam:arduino_due_x
+          - arduino:samd:arduino_zero_native
+          - arduino:samd:tian
+          - esp32:esp32:esp32
+          - esp32:esp32:esp32s2
+          - esp32:esp32:esp32s3
+          - esp32:esp32:esp32c3
+          - esp32:esp32:esp32c6
+          - esp32:esp32:esp32h2
+          - esp8266:esp8266:generic
+          - teensy:avr:teensy40
+
+          # Not yet supported, not in standard library
+          # - esp32:esp32:nano_nora
+
+          # End strategy matrix
     env:
       REPO_OWNER: ${{ github.repository_owner }}
+
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
@@ -80,7 +125,7 @@ jobs:
         run: |
           # Script to fetch and run install.sh from arduino/arduino-cli
 
-          # The install script will test to see if the recently installed apps in in the path
+          # The install script will test to see if the recently installed apps in the path
           # So set it up in advance:
           mkdir -p "${PWD}/bin"
           echo "${PWD}/bin" >> $GITHUB_PATH
@@ -91,7 +136,7 @@ jobs:
           # Ensures that BINDIR exists before the installer runs
           mkdir -p "$ROOT_BIN"
 
-          # Save as a lobal environment variable
+          # Save as a global environment variable
           echo "$ROOT_BIN" >> "$GITHUB_PATH"
 
           # Download and run install script from Arduino:
@@ -122,34 +167,53 @@ jobs:
             echo "Alternative install script not needed."
           fi
 
-      - name: Confirm Arduino CLI install
+      - name: Confirm Arduino CLI Install
         run: arduino-cli version
+
+      - name: Derive CORE_ID (vendor:arch from FQBN)
+        run: |
+          CORE_ID="$(echo '${{ matrix.fqbn }}' | cut -d: -f1-2)"
+          echo "CORE_ID=$CORE_ID" >> "$GITHUB_ENV"
 
       - name: Setup Arduino CLI
         run: |
           arduino-cli config init
-          arduino-cli core update-index
+
+          # wait 10 minutes for big downloads (or use 0 for no limit)
+          arduino-cli config set network.connection_timeout 600s
+
           arduino-cli config add board_manager.additional_urls https://www.pjrc.com/teensy/package_teensy_index.json
-          arduino-cli core update-index
           arduino-cli config add board_manager.additional_urls https://arduino.esp8266.com/stable/package_esp8266com_index.json
           arduino-cli core update-index
-          arduino-cli core install esp32:esp32            # ESP32
-          arduino-cli core install arduino:avr            # Arduino Uno, Mega, Nano
-          arduino-cli core install arduino:sam            # Arduino Due
-          arduino-cli core install arduino:samd           # Arduino Zero
-          arduino-cli core install teensy:avr             # PJRC Teensy
-          arduino-cli core install esp8266:esp8266        # ESP8266
-          arduino-cli core install arduino:mbed_nano      # nanorp2040connect
-          arduino-cli core install arduino:mbed_portenta  # portenta_h7_m7
-          arduino-cli core install arduino:mbed_edge
+
+          echo "CORE_ID: $CORE_ID"
+          arduino-cli core install "$CORE_ID"
+
+          # The above is instead of:
+          # arduino-cli core install esp32:esp32            # ESP32
+          # arduino-cli core install arduino:avr            # Arduino Uno, Mega, Nano
+          # arduino-cli core install arduino:sam            # Arduino Due
+          # arduino-cli core install arduino:samd           # Arduino Zero
+          # arduino-cli core install teensy:avr             # PJRC Teensy
+          # arduino-cli core install esp8266:esp8266        # ESP8266
+          # arduino-cli core install arduino:mbed_nano      # nanorp2040connect
+          # arduino-cli core install arduino:mbed_portenta  # portenta_h7_m7
+          # arduino-cli core install arduino:mbed_edge
+          # arduino-cli core install arduino:renesas_uno
+
+          # For reference:
+
+          # mbed nano not yet tested
           # sudo "/home/$USER/.arduino15/packages/arduino/hardware/mbed_nano/4.2.4/post_install.sh"
-          arduino-cli core install arduino:renesas_uno
+
+          # Always install networking (not part of FQBN matrix)
+          # The first one also creates directory: /home/runner/Arduino/libraries
           arduino-cli lib install "ArduinoJson"           # Example dependency
           arduino-cli lib install "WiFiNINA"              # ARDUINO_SAMD_NANO_33_IOT
           arduino-cli lib install "Ethernet"              # Install Ethernet library
           arduino-cli lib install "Bridge"                # Pseudo-network for things like arduino:samd:tian
 
-      - name: Set job environment variables
+      - name: Set Job Environment Variables
         run: |
           # Script to assign some common environment variables after everything is installed
 
@@ -175,6 +239,26 @@ jobs:
           # WOLFSSL_EXAMPLES_ROOT is the report root, not example location
           echo "WOLFSSL_EXAMPLES_ROOT = $WOLFSSL_EXAMPLES_ROOT"
 
+      - name: Cache Arduino Packages
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.arduino15
+            ~/.cache/arduino
+            ~/.arduino15/staging
+
+            # Arduino libraries
+            # Specific to Arduino CI Build (2 of 4) Arduinbo Release wolfSSL for Local Examples
+            # Include all libraries, as the latest Arduino-wolfSSL will only change upon release.
+            ~/Arduino/libraries
+            # Ensure wolfssl is not cached, we're always using the latest. See separate cache.
+            !~/Arduino/libraries/wolfssl
+          key: arduino-${{ runner.os }}-${{ env.CORE_ID }}-${{ hashFiles('Arduino/sketches/board_list.txt') }}
+
+          restore-keys: |
+               arduino-${{ runner.os }}-${{ env.CORE_ID }}-
+               arduino-${{ runner.os }}-
+
       - name: Show wolfssl-examples
         run: |
           # The examples are local in this wolfssl-example repo, but should have been copied to library, above
@@ -182,9 +266,9 @@ jobs:
 
           # end Show wolfssl-examples
 
-      - name: Shallow clone wolfssl
+      - name: Shallow Clone wolfssl
         run: |
-          # Clone the wolfssl to use for example build
+          # Clone the latest wolfssl to use for building examples
 
           git clone --depth 1 https://github.com/$REPO_OWNER/wolfssl.git
 
@@ -206,9 +290,24 @@ jobs:
           fi
           # end wolfssl source
 
+      - name: Get wolfSSL Commit
+        id: wolfsha
+        run: echo "sha=$(git -C wolfssl rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
+
+      - name: Cache wolfSSL Arduino library
+        id: cache-wolfssl
+        uses: actions/cache@v4
+        with:
+          path: ${{ env.ARDUINO_ROOT }}/wolfssl
+          key: wolfssl-lib-${{ runner.os }}-${{ steps.wolfsha.outputs.sha }}-${{ hashFiles('wolfssl/IDE/ARDUINO/wolfssl-arduino.sh') }}-${{ hashFiles('Arduino/sketches/**') }}
+
       - name: Install wolfSSL Arduino library
+        if: steps.cache-wolfssl.outputs.cache-hit != 'true'
         run: |
           # Install wolfssl via wolfssl-arduino.sh install script
+
+          echo "Installing wolfSSL Arduino library (no cache hit)."
+          rm -rf "$ARDUINO_ROOT/wolfssl"
 
           # Even though the examples are in this library, we'll test as installed for library publishing.
           # When WOLFSSL_EXAMPLES_ROOT is set, the examples will be copied from that path to the published library.
@@ -251,19 +350,22 @@ jobs:
           echo "Current directory     = $PWD"
           echo "ARDUINO_ROOT          = $ARDUINO_ROOT"
           echo "WOLFSSL_EXAMPLES_ROOT = $WOLFSSL_EXAMPLES_ROOT"
+          echo "FQBN                  = ${{ matrix.fqbn }}"
 
+          echo "Change directory to Arduino examples..."
           pushd ./Arduino/sketches
             chmod +x ./compile-all-examples.sh
 
             # The script expects all the examples to be in the current directory.
-            # So copy from local directory to newly instlled wolfssl arduino library to compile there.
+            # So copy from local directory to newly installed wolfssl arduino library to compile there.
             cp ./compile-all-examples.sh "$ARDUINO_ROOT/wolfssl/examples/compile-all-examples.sh"
             cp ./board_list.txt          "$ARDUINO_ROOT/wolfssl/examples/board_list.txt"
 
-            # Compile the Arduino library examples in-place
+            # Compile the Arduino library examples in-place. All examples compiled for FQBN
+            # The respective FQBN board, examples, and optional exclusions must be in board_list.txt
             pushd "$ARDUINO_ROOT/wolfssl/examples/"
               echo "PWD=$PWD"
-              ./compile-all-examples.sh ./board_list.txt
+              ./compile-all-examples.sh ./board_list.txt "${{ matrix.fqbn }}"
             popd
           popd
 

--- a/Arduino/sketches/board_list.txt
+++ b/Arduino/sketches/board_list.txt
@@ -28,7 +28,11 @@
 # To view available boards:
 #   arduino-cli board listall | grep '^esp32:esp32:'
 #
-
+# When updating this list:
+#
+#            >>>>> Update arduino-release.yml and arduino.yml  <<<<<
+#
+#
 arduino:avr:leonardoeth
     # Ethernet Leonardo ETH (ATmega32u4 + W5500 Ethernet), only 2K RAM
   --no-wolfssl_AES_CTR     # Global variables use 4973 bytes (194%) of dynamic memory, leaving -2413 bytes for local variables. Maximum is 2560 bytes.


### PR DESCRIPTION
Add FQBN parameter to `compile_all_examples.sh` to aid in GitHub workflow concurrency.

New syntax adds optional Arduino Fully Qualified Board Name as last parameter:

```
./compile_all_examples.sh  board_list.txt  [FQBN]
```

# Background

All the examples for all the boards in `board_list.txt` are compiled. When the new `[FQBN]` is added, all the examples for that specific board are compiled. Note that the [board_list.txt](https://github.com/wolfSSL/wolfssl-examples/blob/master/Arduino/sketches/board_list.txt) contains exclusions for apps known to fail (e.g. TLS on a board without networking)

Examples, script, and board list are copied to `wolfssl` and `Arduino-wolfssl` during respective workflow runs. This PR is needed to improve [Arduino workflow in wolfSSL repo](https://github.com/wolfSSL/wolfssl/blob/master/.github/workflows/arduino.yml) performance.

See tests: 

# This PR - Workflows in wolfssl-examples

## Arduino CI Build (2 of 4) Release Arduino wolfSSL for Local Examples 

Workflow in [arduino-release.yml](https://github.com/gojimmypi/wolfssl-examples/blob/master/.github/workflows/arduino-release.yml), see https://github.com/gojimmypi/wolfssl-examples/actions/runs/19397103267

## Arduino CI Build (3 of 4) Latest wolfSSL for Local Examples update 

Workflow in [arduino.yml](https://github.com/gojimmypi/wolfssl-examples/blob/master/.github/workflows/arduino.yml), see  https://github.com/gojimmypi/wolfssl-examples/actions/runs/19397103269

# Other repo changes needed

## Arduino CI Build (1 of 4) wolfssl wolfSSL update [arduino.yml](https://github.com/gojimmypi/wolfssl/blob/ED25519_SHA2_fix/.github/workflows/arduino.yml)  
Depends on this PR merged first. Example:
- https://github.com/gojimmypi/wolfssl/actions/runs/19397535547

## Arduino CI Build (4 of 4) Arduino-wolfSSL update [arduino.yml](https://github.com/gojimmypi/Arduino-wolfSSL/blob/pr-arduino-testing/.github/workflows/arduino.yml)

Depends on this PR merged first. Example:
- https://github.com/gojimmypi/Arduino-wolfSSL/actions/runs/19397066531

# CAUTION

The enclosed `Arduino/sketches/compile-all-examples.sh` is pulled in by wolfssl repo workflow:

https://github.com/wolfSSL/wolfssl/blob/master/.github/workflows/arduino.yml
