### PR TITLE
Add RFC 9421 HTTP Message Signatures example using wolfCrypt Ed25519

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -412,5 +412,11 @@ stsafe/stsafe_test
 stsafe/wolfssl_stsafe_test
 stsafe/wolfssl_stsafe_full_test
 
+# HTTP Message Signatures (RFC 9421) example
+http-message-signatures/sign_request
+http-message-signatures/test_vectors
+http-message-signatures/http_server_verify
+http-message-signatures/http_client_signed
+
 # uefi-library generated filesystem content
 uefi-library/efifs

--- a/README.md
+++ b/README.md
@@ -391,6 +391,19 @@ details.
 
 <br />
 
+#### http-message-signatures (RFC 9421 HTTP Message Signatures)
+
+This directory contains examples that demonstrate RFC 9421 HTTP Message
+Signatures using wolfCrypt Ed25519, including a signing example,
+client/server demo, and test vectors for RFC 9421 Appendix B.2.6.
+
+Please see the
+[http-message-signatures/README.md](http-message-signatures/README.md)
+for further usage and details.
+
+
+<br />
+
 #### uefi-library (wolfCrypt UEFI boot module and test app)
 
 This directory contains a UEFI wolfCrypt protocol driver (`libwolfcrypt.efi`)

--- a/http-message-signatures/Makefile
+++ b/http-message-signatures/Makefile
@@ -1,0 +1,35 @@
+CC ?= gcc
+WOLFSSL_INSTALL_DIR = /usr/local
+CFLAGS = -I$(WOLFSSL_INSTALL_DIR)/include -I. -Wall -Wextra
+LDFLAGS = -L$(WOLFSSL_INSTALL_DIR)/lib
+LDLIBS = -lwolfssl
+
+COMMON_SRC = common/wc_sf.c common/wc_http_sig.c
+COMMON_OBJ = $(COMMON_SRC:.c=.o)
+
+TARGETS = sign_request test_vectors http_server_verify http_client_signed
+
+all: $(TARGETS)
+
+sign_request: sign_request.o $(COMMON_OBJ)
+	$(CC) -o $@ $^ $(LDFLAGS) $(LDLIBS)
+
+test_vectors: test_vectors.o $(COMMON_OBJ)
+	$(CC) -o $@ $^ $(LDFLAGS) $(LDLIBS)
+
+http_server_verify: http_server_verify.o $(COMMON_OBJ)
+	$(CC) -o $@ $^ $(LDFLAGS) $(LDLIBS)
+
+http_client_signed: http_client_signed.o $(COMMON_OBJ)
+	$(CC) -o $@ $^ $(LDFLAGS) $(LDLIBS)
+
+%.o: %.c
+	$(CC) -c -o $@ $< $(CFLAGS)
+
+.PHONY: all clean test
+
+clean:
+	rm -f $(TARGETS) *.o common/*.o
+
+test: test_vectors
+	./test_vectors

--- a/http-message-signatures/README.md
+++ b/http-message-signatures/README.md
@@ -1,0 +1,92 @@
+# RFC 9421 HTTP Message Signatures with wolfCrypt
+
+Minimal [RFC 9421](https://www.rfc-editor.org/rfc/rfc9421) implementation
+using wolfCrypt Ed25519. Covers derived components (`@method`, `@authority`,
+`@path`, `@query`), arbitrary headers, timestamp validation, and `keyid`
+extraction. Single signature (`sig1`), Ed25519 only.
+
+## Quick start
+
+```sh
+# wolfSSL prerequisite
+cd wolfssl && ./configure --enable-ed25519 --enable-coding && make && sudo make install
+
+# Build and test
+cd http-message-signatures
+make
+make test        # 17 tests including RFC 9421 B.2.6 vector
+./sign_request   # standalone signing example
+```
+
+## Client/server demo
+
+```sh
+./http_server_verify &   # terminal 1
+./http_client_signed     # terminal 2
+```
+
+The client sends three requests: a valid signed POST (→ 200), a tampered
+request (→ 401), and a valid signed GET (→ 200).
+
+## API
+
+```c
+/* Sign — outputs NUL-terminated Signature and Signature-Input header values */
+int wc_HttpSig_Sign(
+    const char* method, const char* authority,
+    const char* path, const char* query,
+    const wc_HttpHeader* headers, int headerCount,
+    ed25519_key* key, const char* keyId, long created,
+    char* sigOut, word32* sigOutSz,
+    char* inputOut, word32* inputOutSz);
+
+/* Extract keyid from Signature-Input */
+int wc_HttpSig_GetKeyId(
+    const char* signatureInput, const char* label,
+    char* keyIdOut, word32* keyIdOutSz);
+
+/* Verify — returns 0 on success; maxAgeSec=0 skips timestamp check */
+int wc_HttpSig_Verify(
+    const char* method, const char* authority,
+    const char* path, const char* query,
+    const wc_HttpHeader* headers, int headerCount,
+    const char* signature, const char* signatureInput,
+    const char* label, ed25519_key* pubKey, int maxAgeSec);
+```
+
+Typical verify flow:
+
+```
+1. wc_HttpSig_GetKeyId(sigInput, label, keyIdBuf, &sz)
+2. my_key_store_lookup(keyIdBuf) → pubKey
+3. wc_HttpSig_Verify(..., pubKey, maxAgeSec)
+```
+
+## Limitations
+
+- **No body protection** — no `content-digest` (RFC 9530); signatures cover
+  components and headers only
+- **No replay prevention** — `maxAgeSec` limits the window; nonce tracking
+  is the caller's responsibility
+- **Duplicate headers** — first match wins, no folding
+- **Y2038** — `created` uses `long`; overflows on platforms where `long` is
+  32-bit (all 32-bit targets and 64-bit Windows/LLP64) after 2038-01-19
+- **Canonicalization** — signer and verifier must agree on component
+  representation; intermediaries that rewrite headers will break verification
+
+## Files
+
+```
+common/wc_http_sig.{c,h}   RFC 9421 sign/verify/getKeyId
+common/wc_sf.{c,h}         RFC 8941 structured fields (subset)
+sign_request.c              Standalone signing example
+http_server_verify.c        Demo server with signature verification
+http_client_signed.c        Demo client sending signed requests
+test_vectors.c              17 tests including RFC 9421 B.2.6
+```
+
+## References
+
+- [RFC 9421 — HTTP Message Signatures](https://www.rfc-editor.org/rfc/rfc9421)
+- [RFC 8941 — Structured Field Values for HTTP](https://www.rfc-editor.org/rfc/rfc8941)
+- [wolfSSL Ed25519 Documentation](https://www.wolfssl.com/documentation/manuals/wolfssl/group__ED25519.html)

--- a/http-message-signatures/common/wc_http_sig.c
+++ b/http-message-signatures/common/wc_http_sig.c
@@ -1,0 +1,500 @@
+/* wc_http_sig.c
+ *
+ * RFC 9421 HTTP Message Signatures using wolfCrypt Ed25519.
+ *
+ * Copyright (C) 2006-2026 wolfSSL Inc.
+ *
+ * This file is part of wolfSSL.
+ *
+ * wolfSSL is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * wolfSSL is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
+ */
+
+#include "wc_http_sig.h"
+#include "wc_sf.h"
+
+#ifdef HAVE_ED25519
+
+#include <wolfssl/wolfcrypt/ed25519.h>
+#include <wolfssl/wolfcrypt/error-crypt.h>
+#include <wolfssl/wolfcrypt/logging.h>
+#include <limits.h>
+
+/* --- Internal helpers --- */
+
+static int to_lower(int c)
+{
+    return (c >= 'A' && c <= 'Z') ? c + ('a' - 'A') : c;
+}
+
+/* Lowercase a string in-place (RFC 9421 Section 2.1 requires lowercased
+ * component identifiers for HTTP field names). */
+static void str_to_lower(char* s)
+{
+    while (*s) {
+        *s = (char)to_lower((unsigned char)*s);
+        s++;
+    }
+}
+
+/* Case-insensitive string comparison (RFC 9421 requires case-insensitive
+ * header name matching per HTTP semantics). */
+static int strcasecmp_internal(const char* a, const char* b)
+{
+    while (*a && *b) {
+        int ca = to_lower((unsigned char)*a);
+        int cb = to_lower((unsigned char)*b);
+        if (ca != cb)
+            return ca - cb;
+        a++;
+        b++;
+    }
+    return (unsigned char)*a - (unsigned char)*b;
+}
+
+/* Skip leading OWS (optional whitespace: SP / HTAB) per RFC 9110.
+ * Intentionally duplicated from wc_sf.c for module independence. */
+static const char* skip_ows(const char* p)
+{
+    while (*p == ' ' || *p == '\t')
+        p++;
+    return p;
+}
+
+/* Return length of value excluding trailing OWS */
+static int trimmed_len(const char* val)
+{
+    int len = (int)XSTRLEN(val);
+    while (len > 0 && (val[len - 1] == ' ' || val[len - 1] == '\t'))
+        len--;
+    return len;
+}
+
+/* Check if a derived component name is one we support.
+ * Returns 1 if known, 0 if unknown. */
+static int is_known_derived(const char* name)
+{
+    return (XSTRCMP(name, "@method") == 0 ||
+            XSTRCMP(name, "@authority") == 0 ||
+            XSTRCMP(name, "@path") == 0 ||
+            XSTRCMP(name, "@query") == 0);
+}
+
+/* --- Internal: resolve a component value from request data --- */
+
+/* Lookup the value for a component identifier.
+ * Derived components start with '@'; everything else is a header name.
+ * Header name matching is case-insensitive per HTTP semantics. */
+static const char* resolve_component(const char* name,
+                                     const char* method,
+                                     const char* authority,
+                                     const char* path,
+                                     const char* query,
+                                     const wc_HttpHeader* headers,
+                                     int headerCount)
+{
+    if (name[0] == '@') {
+        if (XSTRCMP(name, "@method") == 0)    return method;
+        if (XSTRCMP(name, "@authority") == 0) return authority;
+        if (XSTRCMP(name, "@path") == 0)      return path;
+        if (XSTRCMP(name, "@query") == 0)     return query;
+        return NULL;
+    }
+
+    /* Search headers case-insensitively */
+    {
+        int i;
+        for (i = 0; i < headerCount; i++) {
+            if (strcasecmp_internal(headers[i].name, name) == 0)
+                return headers[i].value;
+        }
+    }
+    return NULL;
+}
+
+/* --- Internal: build signature base (RFC 9421 Section 2.5) --- */
+
+/* Append to buffer with bounds checking. Returns new position or -1. */
+static int buf_append(char* buf, int pos, int maxSz, const char* str)
+{
+    int len = (int)XSTRLEN(str);
+    if (pos + len >= maxSz)
+        return -1;
+    XMEMCPY(buf + pos, str, len);
+    return pos + len;
+}
+
+/* Build the signature base from components and request data.
+ *
+ * The signature base is:
+ *   For each component in order:
+ *     "<component-id>": <value>\n
+ *   Final line (no trailing \n):
+ *     "@signature-params": <sig-params-value>
+ */
+static int build_signature_base(
+    const char**         componentNames,
+    int                  componentCount,
+    const char*          method,
+    const char*          authority,
+    const char*          path,
+    const char*          query,
+    const wc_HttpHeader* headers,
+    int                  headerCount,
+    const char*          sigParamsValue,
+    char*                baseOut,
+    word32*              baseOutSz)
+{
+    char* buf = baseOut;
+    int pos = 0;
+    int maxSz;
+    int i;
+
+    if (*baseOutSz > (word32)INT_MAX)
+        return BAD_FUNC_ARG;
+    maxSz = (int)*baseOutSz;
+
+    for (i = 0; i < componentCount; i++) {
+        const char* val;
+        int valLen;
+
+        val = resolve_component(componentNames[i],
+                                method, authority, path, query,
+                                headers, headerCount);
+        if (!val)
+            return BAD_FUNC_ARG;
+
+        pos = buf_append(buf, pos, maxSz, "\"");
+        if (pos < 0) return BUFFER_E;
+        pos = buf_append(buf, pos, maxSz, componentNames[i]);
+        if (pos < 0) return BUFFER_E;
+        pos = buf_append(buf, pos, maxSz, "\": ");
+        if (pos < 0) return BUFFER_E;
+
+        if (componentNames[i][0] != '@') {
+            val = skip_ows(val);
+            valLen = trimmed_len(val);
+            if (pos + valLen >= maxSz)
+                return BUFFER_E;
+            XMEMCPY(buf + pos, val, valLen);
+            pos += valLen;
+        } else {
+            pos = buf_append(buf, pos, maxSz, val);
+            if (pos < 0) return BUFFER_E;
+        }
+
+        pos = buf_append(buf, pos, maxSz, "\n");
+        if (pos < 0) return BUFFER_E;
+    }
+
+    pos = buf_append(buf, pos, maxSz, "\"@signature-params\": ");
+    if (pos < 0) return BUFFER_E;
+    pos = buf_append(buf, pos, maxSz, sigParamsValue);
+    if (pos < 0) return BUFFER_E;
+
+    *baseOutSz = (word32)pos;
+    return 0;
+}
+
+/* --- Public API: Sign --- */
+
+#ifdef HAVE_ED25519_SIGN
+int wc_HttpSig_Sign(
+    const char*          method,
+    const char*          authority,
+    const char*          path,
+    const char*          query,
+    const wc_HttpHeader* headers,
+    int                  headerCount,
+    ed25519_key*         key,
+    const char*          keyId,
+    long                 created,
+    char*                sigOut,
+    word32*              sigOutSz,
+    char*                inputOut,
+    word32*              inputOutSz)
+{
+    int ret;
+    wc_SfSigInput sfIn;
+    char sigParams[1024];
+    word32 sigParamsSz;
+    char sigBase[WC_HTTPSIG_MAX_SIG_BASE];
+    word32 sigBaseSz;
+    byte rawSig[ED25519_SIG_SIZE];
+    word32 rawSigSz = ED25519_SIG_SIZE;
+    const char* componentNames[WC_HTTPSIG_MAX_COMPONENTS];
+    int componentCount = 0;
+    int i;
+
+    if (!method || !authority || !path || !key || !keyId ||
+        !sigOut || !sigOutSz || !inputOut || !inputOutSz)
+        return BAD_FUNC_ARG;
+    if (headerCount < 0 || (headerCount > 0 && !headers))
+        return BAD_FUNC_ARG;
+
+    if (created == 0)
+        created = (long)XTIME(NULL);
+
+    /* Build wc_SfSigInput structure with component names.
+     * Derived components first, then headers.
+     * Header names are lowercased per RFC 9421 Section 2.1. */
+    XMEMSET(&sfIn, 0, sizeof(sfIn));
+    XSTRNCPY(sfIn.label, WC_HTTPSIG_DEFAULT_LABEL, WC_SF_MAX_LABEL - 1);
+
+    if (3 + (query ? 1 : 0) + headerCount > WC_HTTPSIG_MAX_COMPONENTS)
+        return BUFFER_E;
+
+    XSTRNCPY(sfIn.items[componentCount], "@method", WC_SF_MAX_STRING - 1);
+    componentNames[componentCount] = sfIn.items[componentCount];
+    componentCount++;
+
+    XSTRNCPY(sfIn.items[componentCount], "@authority", WC_SF_MAX_STRING - 1);
+    componentNames[componentCount] = sfIn.items[componentCount];
+    componentCount++;
+
+    XSTRNCPY(sfIn.items[componentCount], "@path", WC_SF_MAX_STRING - 1);
+    componentNames[componentCount] = sfIn.items[componentCount];
+    componentCount++;
+
+    if (query) {
+        XSTRNCPY(sfIn.items[componentCount], "@query", WC_SF_MAX_STRING - 1);
+        componentNames[componentCount] = sfIn.items[componentCount];
+        componentCount++;
+    }
+
+    for (i = 0; i < headerCount; i++) {
+        if (componentCount >= WC_HTTPSIG_MAX_COMPONENTS)
+            return BUFFER_E;
+        XSTRNCPY(sfIn.items[componentCount], headers[i].name,
+                 WC_SF_MAX_STRING - 1);
+        str_to_lower(sfIn.items[componentCount]);
+        componentNames[componentCount] = sfIn.items[componentCount];
+        componentCount++;
+    }
+    sfIn.itemCount = componentCount;
+
+    XSTRNCPY(sfIn.params[0].name, "created", WC_SF_MAX_LABEL - 1);
+    sfIn.params[0].type = WC_SF_PARAM_INTEGER;
+    sfIn.params[0].intVal = created;
+
+    XSTRNCPY(sfIn.params[1].name, "keyid", WC_SF_MAX_LABEL - 1);
+    sfIn.params[1].type = WC_SF_PARAM_STRING;
+    XSTRNCPY(sfIn.params[1].strVal, keyId, WC_SF_MAX_STRING - 1);
+
+    XSTRNCPY(sfIn.params[2].name, "alg", WC_SF_MAX_LABEL - 1);
+    sfIn.params[2].type = WC_SF_PARAM_STRING;
+    XSTRNCPY(sfIn.params[2].strVal, "ed25519", WC_SF_MAX_STRING - 1);
+    sfIn.paramCount = 3;
+
+    sigParamsSz = (word32)sizeof(sigParams);
+    ret = wc_SfGenSigParams(&sfIn, sigParams, &sigParamsSz);
+    if (ret != 0)
+        return ret;
+
+    sigBaseSz = (word32)sizeof(sigBase);
+    ret = build_signature_base(
+        componentNames, componentCount,
+        method, authority, path, query,
+        headers, headerCount,
+        sigParams,
+        sigBase, &sigBaseSz);
+    if (ret != 0)
+        return ret;
+
+    ret = wc_ed25519_sign_msg((const byte*)sigBase, sigBaseSz,
+                              rawSig, &rawSigSz, key);
+    if (ret != 0)
+        return ret;
+
+    ret = wc_SfGenSigValue(WC_HTTPSIG_DEFAULT_LABEL,
+                           rawSig, rawSigSz,
+                           sigOut, sigOutSz);
+    if (ret != 0)
+        return ret;
+
+    ret = wc_SfGenSigInput(&sfIn, inputOut, inputOutSz);
+    if (ret != 0)
+        return ret;
+
+    return 0;
+}
+
+#endif /* HAVE_ED25519_SIGN */
+
+/* --- Public API: GetKeyId --- */
+
+int wc_HttpSig_GetKeyId(
+    const char*          signatureInput,
+    const char*          label,
+    char*                keyIdOut,
+    word32*              keyIdOutSz)
+{
+    int ret, i;
+    wc_SfSigInput parsed;
+
+    if (!signatureInput || !keyIdOut || !keyIdOutSz)
+        return BAD_FUNC_ARG;
+
+    ret = wc_SfParseSigInput(signatureInput, label, &parsed);
+    if (ret != 0)
+        return ret;
+
+    for (i = 0; i < parsed.paramCount; i++) {
+        if (XSTRCMP(parsed.params[i].name, "keyid") == 0) {
+            word32 len;
+            if (parsed.params[i].type != WC_SF_PARAM_STRING)
+                return BAD_FUNC_ARG;
+            len = (word32)XSTRLEN(parsed.params[i].strVal);
+            if (len + 1 > *keyIdOutSz)
+                return BUFFER_E;
+            XMEMCPY(keyIdOut, parsed.params[i].strVal, len + 1);
+            *keyIdOutSz = len;
+            return 0;
+        }
+    }
+
+    return MISSING_KEY;
+}
+
+/* --- Public API: Verify --- */
+
+#ifdef HAVE_ED25519_VERIFY
+int wc_HttpSig_Verify(
+    const char*          method,
+    const char*          authority,
+    const char*          path,
+    const char*          query,
+    const wc_HttpHeader* headers,
+    int                  headerCount,
+    const char*          signature,
+    const char*          signatureInput,
+    const char*          label,
+    ed25519_key*         pubKey,
+    int                  maxAgeSec)
+{
+    int ret, i;
+    wc_SfSigInput parsed;
+    byte rawSig[ED25519_SIG_SIZE];
+    word32 rawSigSz = ED25519_SIG_SIZE;
+    char usedLabel[WC_SF_MAX_LABEL];
+    char sigParams[1024];
+    word32 sigParamsSz;
+    char sigBase[WC_HTTPSIG_MAX_SIG_BASE];
+    word32 sigBaseSz;
+    const char* componentNames[WC_HTTPSIG_MAX_COMPONENTS];
+    int verifyRes = 0;
+
+    if (!method || !authority || !path || !signature || !signatureInput ||
+        !pubKey)
+        return BAD_FUNC_ARG;
+    if (headerCount < 0 || (headerCount > 0 && !headers))
+        return BAD_FUNC_ARG;
+
+    /* Parse Signature-Input to get covered components and params */
+    ret = wc_SfParseSigInput(signatureInput, label, &parsed);
+    if (ret != 0)
+        return ret;
+
+    XSTRNCPY(usedLabel, parsed.label, WC_SF_MAX_LABEL - 1);
+    usedLabel[WC_SF_MAX_LABEL - 1] = '\0';
+
+    /* Check timestamp if requested */
+    if (maxAgeSec > 0) {
+        long createdTime = 0;
+        int found = 0;
+        for (i = 0; i < parsed.paramCount; i++) {
+            if (XSTRCMP(parsed.params[i].name, "created") == 0 &&
+                parsed.params[i].type == WC_SF_PARAM_INTEGER) {
+                createdTime = parsed.params[i].intVal;
+                found = 1;
+                break;
+            }
+        }
+        if (!found)
+            return BAD_FUNC_ARG;
+
+        {
+            long now = (long)XTIME(NULL);
+            long age = now - createdTime;
+            if (age < 0 || age > maxAgeSec)
+                return SIG_VERIFY_E;
+        }
+    }
+
+    /* Enforce algorithm: if alg is present, it must be ed25519 */
+    for (i = 0; i < parsed.paramCount; i++) {
+        if (XSTRCMP(parsed.params[i].name, "alg") == 0) {
+            if (parsed.params[i].type != WC_SF_PARAM_STRING ||
+                XSTRCMP(parsed.params[i].strVal, "ed25519") != 0)
+                return BAD_FUNC_ARG;
+            break;
+        }
+    }
+
+    /* Extract raw signature bytes */
+    rawSigSz = ED25519_SIG_SIZE;
+    ret = wc_SfParseSigValue(signature, usedLabel, rawSig, &rawSigSz);
+    if (ret != 0)
+        return ret;
+    if (rawSigSz != ED25519_SIG_SIZE)
+        return BAD_FUNC_ARG;
+
+    /* Build the list of component names from the parsed inner list.
+     * Reject unknown derived components (starting with '@') to prevent
+     * a crafted Signature-Input from causing unexpected behavior. */
+    if (parsed.itemCount > WC_HTTPSIG_MAX_COMPONENTS)
+        return BUFFER_E;
+
+    for (i = 0; i < parsed.itemCount; i++) {
+        if (parsed.items[i][0] == '@' && !is_known_derived(parsed.items[i]))
+            return BAD_FUNC_ARG;
+        componentNames[i] = parsed.items[i];
+    }
+
+    /* Extract the raw signature-params value from the Signature-Input
+     * header rather than re-serializing from parsed data. RFC 9421
+     * Section 3.2 requires using the exact original value so that the
+     * reconstructed signature base matches what the signer produced. */
+    sigParamsSz = (word32)sizeof(sigParams);
+    ret = wc_SfExtractRawSigParams(signatureInput, label,
+                                   sigParams, &sigParamsSz);
+    if (ret != 0)
+        return ret;
+
+    /* Build signature base */
+    sigBaseSz = (word32)sizeof(sigBase);
+    ret = build_signature_base(
+        componentNames, parsed.itemCount,
+        method, authority, path, query,
+        headers, headerCount,
+        sigParams,
+        sigBase, &sigBaseSz);
+    if (ret != 0)
+        return ret;
+
+    /* Verify Ed25519 signature */
+    ret = wc_ed25519_verify_msg(rawSig, rawSigSz,
+                                (const byte*)sigBase, sigBaseSz,
+                                &verifyRes, pubKey);
+    if (ret != 0)
+        return ret;
+    if (verifyRes != 1)
+        return SIG_VERIFY_E;
+
+    return 0;
+}
+
+#endif /* HAVE_ED25519_VERIFY */
+
+#endif /* HAVE_ED25519 */

--- a/http-message-signatures/common/wc_http_sig.c
+++ b/http-message-signatures/common/wc_http_sig.c
@@ -104,6 +104,8 @@ static const char* resolve_component(const char* name,
                                      const wc_HttpHeader* headers,
                                      int headerCount)
 {
+    int i;
+
     if (name[0] == '@') {
         if (XSTRCMP(name, "@method") == 0)    return method;
         if (XSTRCMP(name, "@authority") == 0) return authority;
@@ -113,12 +115,9 @@ static const char* resolve_component(const char* name,
     }
 
     /* Search headers case-insensitively */
-    {
-        int i;
-        for (i = 0; i < headerCount; i++) {
-            if (strcasecmp_internal(headers[i].name, name) == 0)
-                return headers[i].value;
-        }
+    for (i = 0; i < headerCount; i++) {
+        if (strcasecmp_internal(headers[i].name, name) == 0)
+            return headers[i].value;
     }
     return NULL;
 }

--- a/http-message-signatures/common/wc_http_sig.h
+++ b/http-message-signatures/common/wc_http_sig.h
@@ -1,0 +1,155 @@
+/* wc_http_sig.h
+ *
+ * RFC 9421 HTTP Message Signatures using wolfCrypt Ed25519.
+ *
+ * Minimal v1 implementation covering:
+ *   - Derived components: @method, @authority, @path, @query
+ *   - Arbitrary HTTP header fields
+ *   - Ed25519 signing and verification
+ *   - Single signature (sig1)
+ *   - Timestamp-based replay protection
+ *
+ * Note: The wc_ prefix is used for consistency with wolfCrypt
+ * naming but these are example functions, not part of wolfCrypt.
+ * Linking this code alongside a future wolfCrypt that adds
+ * identically-named symbols would cause conflicts.
+ *
+ * Copyright (C) 2006-2026 wolfSSL Inc.
+ *
+ * This file is part of wolfSSL.
+ *
+ * wolfSSL is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * wolfSSL is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
+ */
+
+#ifndef WC_HTTP_SIG_H
+#define WC_HTTP_SIG_H
+
+#ifndef WOLFSSL_USER_SETTINGS
+    #include <wolfssl/options.h>
+#endif
+#include <wolfssl/wolfcrypt/settings.h>
+#include <wolfssl/wolfcrypt/types.h>
+
+#ifdef HAVE_ED25519
+
+#include <wolfssl/wolfcrypt/ed25519.h>
+
+/* Maximum sizes for internal buffers.
+ * Reduce WC_HTTPSIG_MAX_SIG_BASE on stack-constrained embedded targets. */
+#define WC_HTTPSIG_MAX_SIG_BASE    4096
+#define WC_HTTPSIG_MAX_COMPONENTS    16
+#define WC_HTTPSIG_MAX_LABEL         64
+
+/* Default signature label */
+#define WC_HTTPSIG_DEFAULT_LABEL   "sig1"
+
+/* HTTP header name-value pair.
+ * Header name matching is case-insensitive. Leading and trailing
+ * whitespace on values is trimmed during signature base construction.
+ * Duplicate headers must be provided as separate entries. */
+typedef struct {
+    const char* name;
+    const char* value;
+} wc_HttpHeader;
+
+#ifdef HAVE_ED25519_SIGN
+/* Sign an HTTP request per RFC 9421.
+ *
+ * method      - HTTP method, e.g. "POST" (uppercase)
+ * authority   - Host authority, e.g. "example.com" (lowercase)
+ * path        - Request path, e.g. "/foo" (no query string)
+ * query       - Query string including "?", e.g. "?x=1", or NULL to omit
+ * headers     - Array of additional HTTP headers to include in signature
+ * headerCount - Number of entries in headers array
+ * key         - Ed25519 private key (must have both private and public parts)
+ * keyId       - Key identifier string, included in Signature-Input
+ * created     - UNIX timestamp for signature creation (0 = use current time)
+ *               Note: on platforms where long is 32-bit, timestamps after
+ *               2038-01-19 will overflow. See Y2038.
+ *
+ * sigOut      - Output buffer for Signature header value
+ * sigOutSz    - In: buffer size. Out: bytes written (NUL-term).
+ * inputOut    - Output buffer for Signature-Input value
+ * inputOutSz  - In: buffer size. Out: bytes written (NUL-term).
+ *
+ * Header names are automatically lowercased per RFC 9421 Section 2.1.
+ *
+ * Returns 0 on success, negative on error. */
+int wc_HttpSig_Sign(
+    const char*          method,
+    const char*          authority,
+    const char*          path,
+    const char*          query,
+    const wc_HttpHeader* headers,
+    int                  headerCount,
+    ed25519_key*         key,
+    const char*          keyId,
+    long                 created,
+    char*                sigOut,
+    word32*              sigOutSz,
+    char*                inputOut,
+    word32*              inputOutSz
+);
+#endif /* HAVE_ED25519_SIGN */
+
+/* Extract the keyid parameter from a Signature-Input header value.
+ *
+ * signatureInput - The Signature-Input header value
+ * label          - Signature label to look up, or NULL for first member
+ * keyIdOut       - Output buffer for the extracted keyid string
+ * keyIdOutSz     - On input: buffer size. On output: bytes written.
+ *
+ * Returns 0 on success, negative on error. */
+int wc_HttpSig_GetKeyId(
+    const char*          signatureInput,
+    const char*          label,
+    char*                keyIdOut,
+    word32*              keyIdOutSz
+);
+
+#ifdef HAVE_ED25519_VERIFY
+/* Verify an HTTP request signature per RFC 9421.
+ *
+ * method          - HTTP method (uppercase)
+ * authority       - Host authority (lowercase)
+ * path            - Request path (no query string)
+ * query           - Query string including "?", or NULL
+ * headers         - Array of HTTP headers from the request
+ * headerCount     - Number of entries in headers array
+ * signature       - Signature header value (e.g. "sig1=:b64:")
+ * signatureInput  - Signature-Input header value
+ * label           - Signature label to verify, or NULL for first member
+ * pubKey          - Ed25519 public key
+ * maxAgeSec       - Maximum allowed age of signature in seconds (0 = skip)
+ *
+ * Returns 0 on success (valid signature), negative on error. */
+int wc_HttpSig_Verify(
+    const char*          method,
+    const char*          authority,
+    const char*          path,
+    const char*          query,
+    const wc_HttpHeader* headers,
+    int                  headerCount,
+    const char*          signature,
+    const char*          signatureInput,
+    const char*          label,
+    ed25519_key*         pubKey,
+    int                  maxAgeSec
+);
+#endif /* HAVE_ED25519_VERIFY */
+
+#endif /* HAVE_ED25519 */
+
+#endif /* WC_HTTP_SIG_H */

--- a/http-message-signatures/common/wc_http_sig.h
+++ b/http-message-signatures/common/wc_http_sig.h
@@ -47,7 +47,13 @@
 #include <wolfssl/wolfcrypt/ed25519.h>
 
 /* Maximum sizes for internal buffers.
- * Reduce WC_HTTPSIG_MAX_SIG_BASE on stack-constrained embedded targets. */
+ *
+ * Stack usage: wc_HttpSig_Sign and wc_HttpSig_Verify use large on-stack
+ * wc_SfSigInput and work buffers. Besides WC_HTTPSIG_MAX_SIG_BASE (and
+ * sigParams[1024] in the .c file), the dominant cost is wc_SfSigInput:
+ * items[WC_SF_MAX_ITEMS][WC_SF_MAX_STRING] plus params (see wc_sf.h).
+ * For embedded targets, tune WC_SF_MAX_STRING, WC_SF_MAX_ITEMS, and
+ * WC_HTTPSIG_MAX_SIG_BASE together, or consider heap-allocating internally. */
 #define WC_HTTPSIG_MAX_SIG_BASE    4096
 #define WC_HTTPSIG_MAX_COMPONENTS    16
 #define WC_HTTPSIG_MAX_LABEL         64
@@ -85,6 +91,8 @@ typedef struct {
  * inputOutSz  - In: buffer size. Out: bytes written (NUL-term).
  *
  * Header names are automatically lowercased per RFC 9421 Section 2.1.
+ *
+ * Stack: see WC_HTTPSIG_* / WC_SF_* sizing note above (can exceed ~12KB).
  *
  * Returns 0 on success, negative on error. */
 int wc_HttpSig_Sign(
@@ -133,6 +141,8 @@ int wc_HttpSig_GetKeyId(
  * label           - Signature label to verify, or NULL for first member
  * pubKey          - Ed25519 public key
  * maxAgeSec       - Maximum allowed age of signature in seconds (0 = skip)
+ *
+ * Stack: same considerations as wc_HttpSig_Sign (large wc_SfSigInput + buffers).
  *
  * Returns 0 on success (valid signature), negative on error. */
 int wc_HttpSig_Verify(

--- a/http-message-signatures/common/wc_sf.c
+++ b/http-message-signatures/common/wc_sf.c
@@ -1,0 +1,493 @@
+/* wc_sf.c
+ *
+ * Minimal RFC 8941 Structured Fields subset for RFC 9421.
+ *
+ * Copyright (C) 2006-2026 wolfSSL Inc.
+ *
+ * This file is part of wolfSSL.
+ *
+ * wolfSSL is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * wolfSSL is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
+ */
+
+#include "wc_sf.h"
+
+#include <wolfssl/wolfcrypt/coding.h>
+#include <wolfssl/wolfcrypt/error-crypt.h>
+#include <limits.h>
+
+/* --- Internal helpers --- */
+
+static const char* skip_ows(const char* p)
+{
+    while (*p == ' ' || *p == '\t')
+        p++;
+    return p;
+}
+
+/* RFC 8941 Section 3.1.2 key character predicates:
+ * key = ( lcalpha / "*" ) *( lcalpha / DIGIT / "_" / "-" / "." / "*" ) */
+static int is_key_start(int c)
+{
+    return (c >= 'a' && c <= 'z') || c == '*';
+}
+
+static int is_key_char(int c)
+{
+    return (c >= 'a' && c <= 'z') || (c >= '0' && c <= '9') ||
+           c == '_' || c == '-' || c == '.' || c == '*';
+}
+
+/* Advance past a dictionary key (token) per RFC 8941 Section 3.1.2. */
+static const char* parse_token(const char* p, char* out, int maxLen)
+{
+    int i = 0;
+    if (!is_key_start((unsigned char)*p)) {
+        out[0] = '\0';
+        return p;
+    }
+    out[i++] = *p++;
+    while (is_key_char((unsigned char)*p) && i < maxLen - 1) {
+        out[i++] = *p++;
+    }
+    out[i] = '\0';
+    return p;
+}
+
+/* Parse a quoted sf-string: DQUOTE *chr DQUOTE
+ * RFC 8941 Section 3.3.3: only \\ and \" are valid escapes. */
+static const char* parse_sf_string(const char* p, char* out, int maxLen)
+{
+    int i = 0;
+    if (*p != '"')
+        return NULL;
+    p++;
+    while (*p && *p != '"' && i < maxLen - 1) {
+        if (*p == '\\') {
+            p++;
+            if (*p != '\\' && *p != '"')
+                return NULL;
+        }
+        out[i++] = *p++;
+    }
+    out[i] = '\0';
+    if (*p != '"')
+        return NULL;
+    p++;
+    return p;
+}
+
+/* Parse an sf-integer (RFC 8941: at least 1 digit, max 15 digits).
+ * Detects overflow against LONG_MAX to handle both 32-bit and 64-bit
+ * platforms correctly. On 32-bit (long = 32-bit), UNIX timestamps after
+ * 2038-01-19 exceed LONG_MAX and will be rejected as overflow. */
+static const char* parse_sf_integer(const char* p, long* val)
+{
+    int neg = 0;
+    long v = 0;
+    int digits = 0;
+    int d;
+    if (*p == '-') { neg = 1; p++; }
+    while (*p >= '0' && *p <= '9' && digits < 15) {
+        d = *p - '0';
+        if (v > (LONG_MAX - d) / 10)
+            return NULL;
+        v = v * 10 + d;
+        p++;
+        digits++;
+    }
+    if (digits == 0)
+        return NULL;
+    if (*p >= '0' && *p <= '9')
+        return NULL; /* exceeds 15-digit sf-integer limit */
+    *val = neg ? -v : v;
+    return p;
+}
+
+/* Parse parameters: *( ";" key ( "=" value ) )
+ * Values can be integers or sf-strings. */
+static const char* parse_params(const char* p, wc_SfParam* params,
+                                int* paramCount, int maxParams)
+{
+    *paramCount = 0;
+    while (*p == ';' && *paramCount < maxParams) {
+        wc_SfParam* param = &params[*paramCount];
+        p++; /* skip ';' */
+        p = skip_ows(p);
+        p = parse_token(p, param->name, WC_SF_MAX_LABEL);
+        if (*p == '=') {
+            p++;
+            if (*p == '"') {
+                param->type = WC_SF_PARAM_STRING;
+                p = parse_sf_string(p, param->strVal, WC_SF_MAX_STRING);
+                if (!p) return NULL;
+            } else {
+                param->type = WC_SF_PARAM_INTEGER;
+                p = parse_sf_integer(p, &param->intVal);
+                if (!p) return NULL;
+            }
+        } else {
+            /* Boolean true parameter (no value) — treat as integer 1 */
+            param->type = WC_SF_PARAM_INTEGER;
+            param->intVal = 1;
+            param->strVal[0] = '\0';
+        }
+        (*paramCount)++;
+    }
+    return p;
+}
+
+/* Skip a quoted sf-string without extracting its value. Handles
+ * escaped characters (\" and \\) so embedded delimiters are not
+ * misinterpreted by the caller. */
+static const char* skip_sf_string(const char* p)
+{
+    if (*p != '"')
+        return p;
+    p++;
+    while (*p && *p != '"') {
+        if (*p == '\\' && *(p + 1))
+            p++;
+        p++;
+    }
+    if (*p == '"')
+        p++;
+    return p;
+}
+
+/* Skip trailing parameters on a dictionary member value.
+ * Parameters can contain quoted strings with arbitrary characters. */
+static const char* skip_params(const char* p)
+{
+    while (*p == ';') {
+        p++;
+        while (*p && *p != ';' && *p != ',') {
+            if (*p == '"') {
+                p = skip_sf_string(p);
+            } else {
+                p++;
+            }
+        }
+    }
+    return p;
+}
+
+/* Find a dictionary member by label.
+ * Returns pointer to the value (after "label="), or NULL. */
+static const char* find_dict_member(const char* input, const char* label,
+                                    char* foundLabel, int labelMax)
+{
+    const char* p = skip_ows(input);
+    while (*p) {
+        char thisLabel[WC_SF_MAX_LABEL];
+        p = skip_ows(p);
+        p = parse_token(p, thisLabel, WC_SF_MAX_LABEL);
+        if (*p != '=') return NULL;
+        p++; /* skip '=' */
+
+        if (label == NULL || XSTRCMP(thisLabel, label) == 0) {
+            if (foundLabel) {
+                XSTRNCPY(foundLabel, thisLabel, labelMax - 1);
+                foundLabel[labelMax - 1] = '\0';
+            }
+            return p;
+        }
+
+        /* Skip value: inner list, byte sequence, or bare item */
+        if (*p == '(') {
+            int depth = 1;
+            p++;
+            while (*p && depth > 0) {
+                if (*p == '"') {
+                    p = skip_sf_string(p);
+                } else {
+                    if (*p == '(') depth++;
+                    else if (*p == ')') depth--;
+                    p++;
+                }
+            }
+            p = skip_params(p);
+        } else if (*p == ':') {
+            p++;
+            while (*p && *p != ':') p++;
+            if (*p == ':') p++;
+            p = skip_params(p);
+        } else {
+            while (*p && *p != ',' && *p != ';' && *p != ' ') p++;
+            p = skip_params(p);
+        }
+        p = skip_ows(p);
+        if (*p == ',') p++;
+    }
+    return NULL;
+}
+
+/* --- Public API ---
+ *
+ * Note: parse errors return ASN_PARSE_E. This reuses the wolfCrypt ASN.1
+ * error code because wolfCrypt does not provide a generic parse error and
+ * defining custom error codes in example code is not appropriate. */
+
+int wc_SfParseSigInput(const char* headerVal, const char* label,
+                       wc_SfSigInput* out)
+{
+    const char* p;
+
+    if (!headerVal || !out)
+        return BAD_FUNC_ARG;
+
+    XMEMSET(out, 0, sizeof(*out));
+
+    p = find_dict_member(headerVal, label, out->label, WC_SF_MAX_LABEL);
+    if (!p)
+        return ASN_PARSE_E;
+
+    /* Expect inner list: ( ... ) */
+    if (*p != '(')
+        return ASN_PARSE_E;
+    p++;
+
+    /* Parse inner list items (sf-strings) */
+    while (*p && *p != ')') {
+        p = skip_ows(p);
+        if (*p == ')') break;
+        if (*p == '"') {
+            if (out->itemCount >= WC_SF_MAX_ITEMS)
+                return BUFFER_E;
+            p = parse_sf_string(p,
+                                out->items[out->itemCount],
+                                WC_SF_MAX_STRING);
+            if (!p) return ASN_PARSE_E;
+            out->itemCount++;
+        } else if (*p == ')') {
+            break;
+        } else {
+            return ASN_PARSE_E;
+        }
+        p = skip_ows(p);
+    }
+
+    if (*p == ')')
+        p++;
+
+    /* Parse parameters */
+    p = parse_params(p, out->params, &out->paramCount, WC_SF_MAX_PARAMS);
+    if (!p)
+        return ASN_PARSE_E;
+
+    return 0;
+}
+
+int wc_SfExtractRawSigParams(const char* headerVal, const char* label,
+                             char* rawOut, word32* rawOutSz)
+{
+    const char* p;
+    const char* start;
+    word32 len;
+
+    if (!headerVal || !rawOut || !rawOutSz)
+        return BAD_FUNC_ARG;
+
+    p = find_dict_member(headerVal, label, NULL, 0);
+    if (!p)
+        return ASN_PARSE_E;
+
+    start = p;
+
+    if (*p != '(')
+        return ASN_PARSE_E;
+    p++;
+    while (*p && *p != ')') {
+        if (*p == '"')
+            p = skip_sf_string(p);
+        else
+            p++;
+    }
+    if (*p == ')')
+        p++;
+
+    p = skip_params(p);
+
+    len = (word32)(p - start);
+    if (len + 1 > *rawOutSz)
+        return BUFFER_E;
+
+    XMEMCPY(rawOut, start, len);
+    rawOut[len] = '\0';
+    *rawOutSz = len;
+    return 0;
+}
+
+/* Append a quoted sf-string with proper escaping of '"' and '\' per
+ * RFC 8941 Section 3.3.3. Returns new position or -1 on overflow. */
+static int sf_append_escaped(char* out, int pos, int maxSz, const char* s)
+{
+    if (pos >= maxSz) return -1;
+    out[pos++] = '"';
+    while (*s) {
+        if (*s == '"' || *s == '\\') {
+            if (pos >= maxSz) return -1;
+            out[pos++] = '\\';
+        }
+        if (pos >= maxSz) return -1;
+        out[pos++] = *s++;
+    }
+    if (pos >= maxSz) return -1;
+    out[pos++] = '"';
+    return pos;
+}
+
+int wc_SfGenSigParams(const wc_SfSigInput* in, char* out, word32* outSz)
+{
+    int i, pos = 0;
+    word32 maxSz;
+
+    if (!in || !out || !outSz)
+        return BAD_FUNC_ARG;
+
+    maxSz = *outSz;
+
+    /* Inner list: ("item1" "item2" ...) */
+    if (pos >= (int)maxSz) return BUFFER_E;
+    out[pos++] = '(';
+
+    for (i = 0; i < in->itemCount; i++) {
+        if (i > 0) {
+            if (pos >= (int)maxSz) return BUFFER_E;
+            out[pos++] = ' ';
+        }
+        pos = sf_append_escaped(out, pos, (int)maxSz, in->items[i]);
+        if (pos < 0) return BUFFER_E;
+    }
+
+    if (pos >= (int)maxSz) return BUFFER_E;
+    out[pos++] = ')';
+
+    /* Parameters: ;name=value */
+    for (i = 0; i < in->paramCount; i++) {
+        int n;
+        if (in->params[i].type == WC_SF_PARAM_INTEGER) {
+            n = XSNPRINTF(out + pos, maxSz - pos, ";%s=%ld",
+                          in->params[i].name, in->params[i].intVal);
+            if (n < 0 || pos + n >= (int)maxSz) return BUFFER_E;
+            pos += n;
+        } else {
+            n = XSNPRINTF(out + pos, maxSz - pos, ";%s=",
+                          in->params[i].name);
+            if (n < 0 || pos + n >= (int)maxSz) return BUFFER_E;
+            pos += n;
+            pos = sf_append_escaped(out, pos, (int)maxSz,
+                                    in->params[i].strVal);
+            if (pos < 0) return BUFFER_E;
+        }
+    }
+
+    if (pos >= (int)maxSz) return BUFFER_E;
+    out[pos] = '\0';
+    *outSz = (word32)pos;
+    return 0;
+}
+
+int wc_SfGenSigInput(const wc_SfSigInput* in, char* out, word32* outSz)
+{
+    int ret;
+    int labelLen;
+    word32 remaining;
+    word32 paramsLen;
+
+    if (!in || !out || !outSz)
+        return BAD_FUNC_ARG;
+
+    /* label= */
+    labelLen = XSNPRINTF(out, *outSz, "%s=", in->label);
+    if (labelLen < 0 || (word32)labelLen >= *outSz)
+        return BUFFER_E;
+
+    remaining = *outSz - (word32)labelLen;
+    paramsLen = remaining;
+    ret = wc_SfGenSigParams(in, out + labelLen, &paramsLen);
+    if (ret != 0)
+        return ret;
+
+    *outSz = (word32)labelLen + paramsLen;
+    return 0;
+}
+
+int wc_SfParseSigValue(const char* headerVal, const char* label,
+                       byte* out, word32* outSz)
+{
+    const char* p;
+    const char* start;
+    const char* end;
+    word32 b64Len;
+
+    if (!headerVal || !out || !outSz)
+        return BAD_FUNC_ARG;
+
+    p = find_dict_member(headerVal, label, NULL, 0);
+    if (!p)
+        return ASN_PARSE_E;
+
+    /* Expect byte sequence: :base64: */
+    if (*p != ':')
+        return ASN_PARSE_E;
+    p++;
+    start = p;
+
+    while (*p && *p != ':')
+        p++;
+    if (*p != ':')
+        return ASN_PARSE_E;
+    end = p;
+
+    b64Len = (word32)(end - start);
+    return Base64_Decode((const byte*)start, b64Len, out, outSz);
+}
+
+int wc_SfGenSigValue(const char* label, const byte* sig, word32 sigSz,
+                     char* out, word32* outSz)
+{
+    int ret;
+    int labelLen;
+    word32 b64Len;
+    word32 remaining;
+
+    if (!label || !sig || !out || !outSz)
+        return BAD_FUNC_ARG;
+
+    /* label=: */
+    labelLen = XSNPRINTF(out, *outSz, "%s=:", label);
+    if (labelLen < 0 || (word32)labelLen >= *outSz)
+        return BUFFER_E;
+
+    remaining = *outSz - (word32)labelLen;
+    if (remaining < 3)
+        return BUFFER_E;
+    b64Len = remaining - 2; /* reserve space for trailing ':' and '\0' */
+
+    ret = Base64_Encode_NoNl(sig, sigSz,
+                             (byte*)(out + labelLen), &b64Len);
+    if (ret != 0)
+        return ret;
+
+    /* Append trailing ':' */
+    if ((word32)labelLen + b64Len + 2 > *outSz)
+        return BUFFER_E;
+
+    out[labelLen + b64Len] = ':';
+    out[labelLen + b64Len + 1] = '\0';
+    *outSz = (word32)labelLen + b64Len + 1;
+
+    return 0;
+}

--- a/http-message-signatures/common/wc_sf.c
+++ b/http-message-signatures/common/wc_sf.c
@@ -356,6 +356,12 @@ int wc_SfGenSigParams(const wc_SfSigInput* in, char* out, word32* outSz)
     if (!in || !out || !outSz)
         return BAD_FUNC_ARG;
 
+    /* Guard the word32 -> int casts below. With the current fixed-size
+     * callers (sigParams[1024]) this is unreachable, but validating here
+     * keeps the function safe if a larger buffer is ever passed in. */
+    if (*outSz > (word32)INT_MAX)
+        return BAD_FUNC_ARG;
+
     maxSz = *outSz;
 
     /* Inner list: ("item1" "item2" ...) */
@@ -407,6 +413,11 @@ int wc_SfGenSigInput(const wc_SfSigInput* in, char* out, word32* outSz)
     word32 paramsLen;
 
     if (!in || !out || !outSz)
+        return BAD_FUNC_ARG;
+
+    /* Same rationale as wc_SfGenSigParams: guard the word32 -> int casts
+     * used inside this function and its callee. */
+    if (*outSz > (word32)INT_MAX)
         return BAD_FUNC_ARG;
 
     /* label= */

--- a/http-message-signatures/common/wc_sf.h
+++ b/http-message-signatures/common/wc_sf.h
@@ -1,0 +1,105 @@
+/* wc_sf.h
+ *
+ * Minimal RFC 8941 Structured Fields subset for RFC 9421.
+ *
+ * Only implements the structured field types needed by HTTP Message
+ * Signatures: dictionary lookup, inner lists with string items,
+ * parameters (integer and string), and byte sequences.
+ *
+ * Note: The wc_ prefix is used for consistency with wolfCrypt
+ * naming but these are example functions, not part of wolfCrypt.
+ * Linking this code alongside a future wolfCrypt that adds
+ * identically-named symbols would cause conflicts.
+ *
+ * Copyright (C) 2006-2026 wolfSSL Inc.
+ *
+ * This file is part of wolfSSL.
+ *
+ * wolfSSL is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * wolfSSL is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
+ */
+
+#ifndef WC_SF_H
+#define WC_SF_H
+
+#ifndef WOLFSSL_USER_SETTINGS
+    #include <wolfssl/options.h>
+#endif
+#include <wolfssl/wolfcrypt/settings.h>
+#include <wolfssl/wolfcrypt/types.h>
+
+#define WC_SF_MAX_ITEMS      16
+#define WC_SF_MAX_PARAMS      8
+#define WC_SF_MAX_STRING    256
+#define WC_SF_MAX_LABEL      64
+
+/* Signature parameter types */
+typedef enum {
+    WC_SF_PARAM_INTEGER,
+    WC_SF_PARAM_STRING
+} wc_SfParamType;
+
+/* A single key=value parameter */
+typedef struct {
+    char            name[WC_SF_MAX_LABEL];
+    wc_SfParamType  type;
+    long            intVal;
+    char            strVal[WC_SF_MAX_STRING];
+} wc_SfParam;
+
+/* Parsed Signature-Input member: inner list + parameters.
+ * Represents: ("@method" "@authority" ...);created=123;keyid="k" */
+typedef struct {
+    char       label[WC_SF_MAX_LABEL];
+    char       items[WC_SF_MAX_ITEMS][WC_SF_MAX_STRING];
+    int        itemCount;
+    wc_SfParam params[WC_SF_MAX_PARAMS];
+    int        paramCount;
+} wc_SfSigInput;
+
+/* Parse a Signature-Input header value, extracting the named member.
+ * If label is NULL, parses the first member found.
+ * Returns 0 on success, negative on error. */
+int wc_SfParseSigInput(const char* headerVal, const char* label,
+                       wc_SfSigInput* out);
+
+/* Generate a Signature-Input member string.
+ * Output: label=(items);params
+ * Returns 0 on success, negative on error. */
+int wc_SfGenSigInput(const wc_SfSigInput* in, char* out, word32* outSz);
+
+/* Generate just the signature-params value (no label=).
+ * Output: (items);params
+ * Used for the @signature-params line in the signature base. */
+int wc_SfGenSigParams(const wc_SfSigInput* in, char* out, word32* outSz);
+
+/* Extract the raw signature-params value for a dictionary member.
+ * Copies the verbatim inner-list + parameters substring (e.g.
+ * ("@method" "@authority");created=123;keyid="k") without
+ * re-serialization. Used by the verify path per RFC 9421 Section 3.2. */
+int wc_SfExtractRawSigParams(const char* headerVal, const char* label,
+                             char* rawOut, word32* rawOutSz);
+
+/* Parse a Signature header value, extracting a byte sequence for the
+ * named member. Decodes the base64 content.
+ * Returns 0 on success, negative on error. */
+int wc_SfParseSigValue(const char* headerVal, const char* label,
+                       byte* out, word32* outSz);
+
+/* Generate a Signature header member: label=:base64(sig):
+ * Returns 0 on success, negative on error. */
+int wc_SfGenSigValue(const char* label, const byte* sig, word32 sigSz,
+                     char* out, word32* outSz);
+
+#endif /* WC_SF_H */

--- a/http-message-signatures/http_client_signed.c
+++ b/http-message-signatures/http_client_signed.c
@@ -205,11 +205,15 @@ static int demo_request(ed25519_key* key,
         inputBuf, inputBufSz,
         tamperHdr, tamperVal,
         httpReq, sizeof(httpReq));
+    if (httpLen < 0) {
+        printf("[Client] Failed to build HTTP request\n");
+        return -1;
+    }
 
     fd = do_connect();
     if (fd < 0) return -1;
 
-    send(fd, httpReq, httpLen, 0);
+    send(fd, httpReq, (size_t)httpLen, 0);
     status = read_response(fd);
     close(fd);
 
@@ -245,6 +249,7 @@ int main(void)
     ret = wc_ed25519_import_private_only(kDemoPrivKey, ED25519_KEY_SIZE, &key);
     if (ret != 0) {
         printf("Failed to import private key: %d\n", ret);
+        wc_ed25519_free(&key);
         return 1;
     }
     {

--- a/http-message-signatures/http_client_signed.c
+++ b/http-message-signatures/http_client_signed.c
@@ -1,0 +1,312 @@
+/* http_client_signed.c
+ *
+ * Minimal HTTP client demonstrating RFC 9421 signed requests using
+ * wolfCrypt Ed25519.
+ *
+ * Connects to localhost:8080 (http_server_verify), signs HTTP requests,
+ * and sends them. Includes a tamper test to demonstrate rejection.
+ *
+ * Build wolfSSL with:
+ *   ./configure --enable-ed25519 --enable-coding && make && sudo make install
+ *
+ * Copyright (C) 2006-2026 wolfSSL Inc.
+ *
+ * This file is part of wolfSSL.
+ *
+ * wolfSSL is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * wolfSSL is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
+ */
+
+#ifndef WOLFSSL_USER_SETTINGS
+    #include <wolfssl/options.h>
+#endif
+#include <wolfssl/wolfcrypt/settings.h>
+#include <wolfssl/wolfcrypt/ed25519.h>
+#include <wolfssl/wolfcrypt/error-crypt.h>
+
+#include <stdio.h>
+#include <string.h>
+#include <unistd.h>
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <arpa/inet.h>
+
+#include "common/wc_http_sig.h"
+
+#if defined(HAVE_ED25519) && defined(HAVE_ED25519_SIGN)
+
+/* Portable case-insensitive string comparison (avoids POSIX strcasecmp
+ * which is unavailable on some toolchains). */
+static int ci_strcmp(const char* a, const char* b)
+{
+    while (*a && *b) {
+        int ca = (*a >= 'A' && *a <= 'Z') ? *a + ('a' - 'A') : *a;
+        int cb = (*b >= 'A' && *b <= 'Z') ? *b + ('a' - 'A') : *b;
+        if (ca != cb) return ca - cb;
+        a++; b++;
+    }
+    return (unsigned char)*a - (unsigned char)*b;
+}
+
+#define SERVER_PORT 8080
+#define MAX_HTTP_SZ 4096
+
+/* RFC 9421 Appendix B.1.4 — Ed25519 private key seed (demo only) */
+static const byte kDemoPrivKey[ED25519_KEY_SIZE] = {
+    0x9f, 0x83, 0x62, 0xf8, 0x7a, 0x48, 0x4a, 0x95,
+    0x4e, 0x6e, 0x74, 0x0c, 0x5b, 0x4c, 0x0e, 0x84,
+    0x22, 0x91, 0x39, 0xa2, 0x0a, 0xa8, 0xab, 0x56,
+    0xff, 0x66, 0x58, 0x6f, 0x6a, 0x7d, 0x29, 0xc5
+};
+
+static int do_connect(void)
+{
+    int fd;
+    struct sockaddr_in addr;
+
+    fd = socket(AF_INET, SOCK_STREAM, 0);
+    if (fd < 0) { perror("socket"); return -1; }
+
+    memset(&addr, 0, sizeof(addr));
+    addr.sin_family = AF_INET;
+    addr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+    addr.sin_port = htons(SERVER_PORT);
+
+    if (connect(fd, (struct sockaddr*)&addr, sizeof(addr)) < 0) {
+        perror("connect (is the server running?)");
+        close(fd);
+        return -1;
+    }
+    return fd;
+}
+
+static int read_response(int fd)
+{
+    char buf[1024];
+    int n, status = 0;
+
+    n = (int)recv(fd, buf, sizeof(buf) - 1, 0);
+    if (n <= 0) {
+        printf("[Client] No response received\n");
+        return -1;
+    }
+    buf[n] = '\0';
+
+    if (sscanf(buf, "HTTP/1.1 %d", &status) != 1)
+        status = 0;
+
+    printf("[Client] Response: %d", status);
+
+    {
+        const char* body = strstr(buf, "\r\n\r\n");
+        if (body) {
+            body += 4;
+            if (*body) printf(" — %s", body);
+        }
+    }
+
+    return status;
+}
+
+/* Build an HTTP/1.1 request string with Signature headers.
+ * If tamperHdr is not NULL, replaces that header's value with tamperVal
+ * in the raw HTTP output (simulating a man-in-the-middle modification). */
+static int build_http_request(
+    const char* method, const char* path, const char* query,
+    const char* authority,
+    wc_HttpHeader* headers, int hdrCount,
+    const char* sigValue, word32 sigValueLen,
+    const char* sigInputValue, word32 sigInputLen,
+    const char* tamperHdr, const char* tamperVal,
+    char* out, int outSz)
+{
+    int pos = 0, n;
+    int i;
+
+#define SAFE_SNPRINTF(pos, out, outSz, ...) do {              \
+    if ((pos) >= (outSz)) return -1;                          \
+    n = snprintf((out) + (pos), (outSz) - (pos), __VA_ARGS__); \
+    if (n < 0 || n >= (outSz) - (pos)) return -1;            \
+    (pos) += n;                                               \
+} while (0)
+
+    SAFE_SNPRINTF(pos, out, outSz, "%s %s%s HTTP/1.1\r\n",
+                  method, path, query ? query : "");
+    SAFE_SNPRINTF(pos, out, outSz, "Host: %s\r\n", authority);
+
+    for (i = 0; i < hdrCount; i++) {
+        const char* val = headers[i].value;
+        if (tamperHdr && ci_strcmp(headers[i].name, tamperHdr) == 0)
+            val = tamperVal;
+        SAFE_SNPRINTF(pos, out, outSz, "%s: %s\r\n",
+                      headers[i].name, val);
+    }
+
+    SAFE_SNPRINTF(pos, out, outSz, "Signature-Input: %.*s\r\n",
+                  (int)sigInputLen, sigInputValue);
+    SAFE_SNPRINTF(pos, out, outSz, "Signature: %.*s\r\n",
+                  (int)sigValueLen, sigValue);
+    SAFE_SNPRINTF(pos, out, outSz, "\r\n");
+
+#undef SAFE_SNPRINTF
+
+    return pos;
+}
+
+static int demo_request(ed25519_key* key,
+                        const char* label,
+                        const char* method,
+                        const char* path,
+                        const char* query,
+                        const char* authority,
+                        wc_HttpHeader* headers, int hdrCount,
+                        const char* tamperHdr, const char* tamperVal,
+                        int expectStatus)
+{
+    char sigBuf[512];
+    word32 sigBufSz = sizeof(sigBuf);
+    char inputBuf[1024];
+    word32 inputBufSz = sizeof(inputBuf);
+    char httpReq[MAX_HTTP_SZ];
+    int httpLen, fd, status, ret;
+
+    printf("\n--- %s ---\n", label);
+    printf("[Client] Signing: %s %s%s\n", method, path, query ? query : "");
+
+    ret = wc_HttpSig_Sign(method, authority, path, query,
+                          headers, hdrCount,
+                          key, "test-key-ed25519", 0,
+                          sigBuf, &sigBufSz,
+                          inputBuf, &inputBufSz);
+    if (ret != 0) {
+        printf("[Client] Sign failed: %d (%s)\n", ret, wc_GetErrorString(ret));
+        return -1;
+    }
+
+    if (tamperHdr)
+        printf("[Client] Tampering: changing %s header after signing\n",
+               tamperHdr);
+
+    httpLen = build_http_request(
+        method, path, query, authority,
+        headers, hdrCount,
+        sigBuf, sigBufSz,
+        inputBuf, inputBufSz,
+        tamperHdr, tamperVal,
+        httpReq, sizeof(httpReq));
+
+    fd = do_connect();
+    if (fd < 0) return -1;
+
+    send(fd, httpReq, httpLen, 0);
+    status = read_response(fd);
+    close(fd);
+
+    if (status == expectStatus) {
+        printf("[Client] Result: correct (expected %d)\n", expectStatus);
+        return 0;
+    } else {
+        printf("[Client] Result: UNEXPECTED (got %d, expected %d)\n",
+               status, expectStatus);
+        return -1;
+    }
+}
+
+int main(void)
+{
+    int ret, failures = 0;
+    ed25519_key key;
+
+    wc_HttpHeader headers[2];
+    headers[0].name  = "Date";
+    headers[0].value = "Thu, 19 Mar 2026 12:00:00 GMT";
+    headers[1].name  = "Content-Type";
+    headers[1].value = "application/json";
+
+    printf("=== RFC 9421 HTTP Client - Signed Requests ===\n");
+    printf("[Client] Connecting to localhost:%d\n", SERVER_PORT);
+
+    ret = wc_ed25519_init(&key);
+    if (ret != 0) {
+        printf("Failed to init key: %d\n", ret);
+        return 1;
+    }
+    ret = wc_ed25519_import_private_only(kDemoPrivKey, ED25519_KEY_SIZE, &key);
+    if (ret != 0) {
+        printf("Failed to import private key: %d\n", ret);
+        return 1;
+    }
+    {
+        byte pubBuf[ED25519_PUB_KEY_SIZE];
+        word32 pubSz = ED25519_PUB_KEY_SIZE;
+        ret = wc_ed25519_make_public(&key, pubBuf, pubSz);
+        if (ret != 0) {
+            printf("Failed to derive public key: %d\n", ret);
+            wc_ed25519_free(&key);
+            return 1;
+        }
+        ret = wc_ed25519_import_private_key(kDemoPrivKey, ED25519_KEY_SIZE,
+                                            pubBuf, pubSz, &key);
+        if (ret != 0) {
+            printf("Failed to import keypair: %d\n", ret);
+            wc_ed25519_free(&key);
+            return 1;
+        }
+    }
+
+    /* Demo 1: Valid signed request */
+    ret = demo_request(&key,
+        "Demo 1: Valid signed request",
+        "POST", "/api/resource", "?action=update",
+        "localhost:8080",
+        headers, 2,
+        NULL, NULL,
+        200);
+    if (ret != 0) failures++;
+
+    /* Demo 2: Tampered header (Date modified after signing) */
+    ret = demo_request(&key,
+        "Demo 2: Tampered request (modified Date)",
+        "POST", "/api/resource", "?action=update",
+        "localhost:8080",
+        headers, 2,
+        "Date", "Fri, 20 Mar 2026 12:00:00 GMT",
+        401);
+    if (ret != 0) failures++;
+
+    /* Demo 3: Valid GET without query */
+    ret = demo_request(&key,
+        "Demo 3: Valid GET request",
+        "GET", "/status", NULL,
+        "localhost:8080",
+        headers, 1,
+        NULL, NULL,
+        200);
+    if (ret != 0) failures++;
+
+    printf("\n=== Results: %d/3 demos passed ===\n", 3 - failures);
+
+    wc_ed25519_free(&key);
+    return failures > 0 ? 1 : 0;
+}
+
+#else
+
+int main(void)
+{
+    printf("This example requires wolfSSL compiled with --enable-ed25519\n");
+    return 1;
+}
+
+#endif

--- a/http-message-signatures/http_server_verify.c
+++ b/http-message-signatures/http_server_verify.c
@@ -1,0 +1,376 @@
+/* http_server_verify.c
+ *
+ * Minimal HTTP/1.1 server demonstrating RFC 9421 signature verification
+ * using wolfCrypt Ed25519.
+ *
+ * Listens on localhost:8080, verifies Signature/Signature-Input headers,
+ * and responds 200 (valid), 401 (invalid), or 400 (missing headers).
+ *
+ * Build wolfSSL with:
+ *   ./configure --enable-ed25519 --enable-coding && make && sudo make install
+ *
+ * Copyright (C) 2006-2026 wolfSSL Inc.
+ *
+ * This file is part of wolfSSL.
+ *
+ * wolfSSL is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * wolfSSL is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
+ */
+
+#ifndef WOLFSSL_USER_SETTINGS
+    #include <wolfssl/options.h>
+#endif
+#include <wolfssl/wolfcrypt/settings.h>
+#include <wolfssl/wolfcrypt/ed25519.h>
+#include <wolfssl/wolfcrypt/error-crypt.h>
+
+#include <stdio.h>
+#include <string.h>
+#include <signal.h>
+#include <unistd.h>
+#include <sys/socket.h>
+#include <sys/time.h>
+#include <netinet/in.h>
+#include <arpa/inet.h>
+
+#include "common/wc_http_sig.h"
+
+#if defined(HAVE_ED25519) && defined(HAVE_ED25519_VERIFY)
+
+/* Portable case-insensitive string comparison with length limit
+ * (avoids POSIX strncasecmp which is unavailable on some toolchains). */
+static int ci_strncmp(const char* a, const char* b, int n)
+{
+    int i;
+    for (i = 0; i < n; i++) {
+        int ca = (a[i] >= 'A' && a[i] <= 'Z') ? a[i] + ('a' - 'A') : a[i];
+        int cb = (b[i] >= 'A' && b[i] <= 'Z') ? b[i] + ('a' - 'A') : b[i];
+        if (ca != cb) return ca - cb;
+        if (ca == 0) return 0;
+    }
+    return 0;
+}
+
+#define LISTEN_PORT  8080
+#define MAX_REQ_SZ   8192
+#define MAX_HDRS     32
+#define HDR_NAME_SZ  128
+#define HDR_VAL_SZ   1024
+
+/* RFC 9421 Appendix B.1.4 — Ed25519 public key (demo only) */
+static const byte kDemoPubKey[ED25519_PUB_KEY_SIZE] = {
+    0x26, 0xb4, 0x0b, 0x8f, 0x93, 0xff, 0xf3, 0xd8,
+    0x97, 0x11, 0x2f, 0x7e, 0xbc, 0x58, 0x2b, 0x23,
+    0x2d, 0xbd, 0x72, 0x51, 0x7d, 0x08, 0x2f, 0xe8,
+    0x3c, 0xfb, 0x30, 0xdd, 0xce, 0x43, 0xd1, 0xbb
+};
+static const char* kDemoKeyId = "test-key-ed25519";
+
+static volatile sig_atomic_t g_running = 1;
+static void on_signal(int sig) { (void)sig; g_running = 0; }
+
+typedef struct {
+    char method[16];
+    char path[512];
+    char query[512];
+    char authority[256];
+
+    char hdrNames[MAX_HDRS][HDR_NAME_SZ];
+    char hdrVals[MAX_HDRS][HDR_VAL_SZ];
+    wc_HttpHeader hdrs[MAX_HDRS];
+    int hdrCount;
+
+    char sig[HDR_VAL_SZ * 2];
+    char sigInput[HDR_VAL_SZ * 2];
+    int hasSig;
+    int hasSigInput;
+} ParsedReq;
+
+static int recv_request(int fd, char* buf, int sz)
+{
+    int total = 0;
+    struct timeval tv;
+    tv.tv_sec = 5;
+    tv.tv_usec = 0;
+    setsockopt(fd, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof(tv));
+
+    while (total < sz - 1) {
+        int n = (int)recv(fd, buf + total, sz - 1 - total, 0);
+        if (n <= 0) break;
+        total += n;
+        buf[total] = '\0';
+        if (strstr(buf, "\r\n\r\n")) break;
+    }
+    return total;
+}
+
+static int parse_request(const char* raw, ParsedReq* req)
+{
+    const char* p = raw;
+    const char* eol;
+    char uri[1024];
+    char* qm;
+    int len;
+
+    memset(req, 0, sizeof(*req));
+
+    /* Request line: METHOD URI HTTP/1.x\r\n */
+    eol = strstr(p, "\r\n");
+    if (!eol) return -1;
+
+    len = 0;
+    while (p < eol && *p != ' ' && len < (int)sizeof(req->method) - 1)
+        req->method[len++] = *p++;
+    req->method[len] = '\0';
+    if (*p == ' ') p++;
+
+    len = 0;
+    while (p < eol && *p != ' ' && len < (int)sizeof(uri) - 1)
+        uri[len++] = *p++;
+    uri[len] = '\0';
+
+    qm = strchr(uri, '?');
+    if (qm) {
+        int pathLen = (int)(qm - uri);
+        if (pathLen >= (int)sizeof(req->path))
+            pathLen = (int)sizeof(req->path) - 1;
+        memcpy(req->path, uri, pathLen);
+        req->path[pathLen] = '\0';
+        strncpy(req->query, qm, sizeof(req->query) - 1);
+    } else {
+        strncpy(req->path, uri, sizeof(req->path) - 1);
+    }
+
+    /* Headers */
+    p = eol + 2;
+    while (*p && !(p[0] == '\r' && p[1] == '\n')) {
+        const char* colon;
+        const char* valStart;
+        int nameLen, valLen;
+
+        eol = strstr(p, "\r\n");
+        if (!eol) break;
+
+        colon = memchr(p, ':', eol - p);
+        if (!colon) { p = eol + 2; continue; }
+
+        nameLen = (int)(colon - p);
+        valStart = colon + 1;
+        while (valStart < eol && *valStart == ' ') valStart++;
+        valLen = (int)(eol - valStart);
+
+        if (nameLen == 15 && ci_strncmp(p, "Signature-Input", 15) == 0) {
+            if (valLen < (int)sizeof(req->sigInput)) {
+                memcpy(req->sigInput, valStart, valLen);
+                req->sigInput[valLen] = '\0';
+                req->hasSigInput = 1;
+            }
+        } else if (nameLen == 9 && ci_strncmp(p, "Signature", 9) == 0) {
+            if (valLen < (int)sizeof(req->sig)) {
+                memcpy(req->sig, valStart, valLen);
+                req->sig[valLen] = '\0';
+                req->hasSig = 1;
+            }
+        } else {
+            if (nameLen == 4 && ci_strncmp(p, "Host", 4) == 0) {
+                if (valLen < (int)sizeof(req->authority)) {
+                    memcpy(req->authority, valStart, valLen);
+                    req->authority[valLen] = '\0';
+                }
+            }
+
+            if (req->hdrCount < MAX_HDRS) {
+                int idx = req->hdrCount;
+                if (nameLen >= HDR_NAME_SZ) nameLen = HDR_NAME_SZ - 1;
+                if (valLen >= HDR_VAL_SZ) valLen = HDR_VAL_SZ - 1;
+                memcpy(req->hdrNames[idx], p, nameLen);
+                req->hdrNames[idx][nameLen] = '\0';
+                memcpy(req->hdrVals[idx], valStart, valLen);
+                req->hdrVals[idx][valLen] = '\0';
+                req->hdrs[idx].name = req->hdrNames[idx];
+                req->hdrs[idx].value = req->hdrVals[idx];
+                req->hdrCount++;
+            }
+        }
+        p = eol + 2;
+    }
+
+    return 0;
+}
+
+static void send_response(int fd, int code,
+                          const char* reason,
+                          const char* body)
+{
+    char resp[1024];
+    int len = snprintf(resp, sizeof(resp),
+        "HTTP/1.1 %d %s\r\n"
+        "Content-Length: %d\r\n"
+        "Connection: close\r\n"
+        "\r\n"
+        "%s",
+        code, reason, (int)strlen(body), body);
+    if (len < 0 || len >= (int)sizeof(resp))
+        return;
+    send(fd, resp, len, 0);
+}
+
+static int handle_request(int fd, ed25519_key* pubKey)
+{
+    char buf[MAX_REQ_SZ];
+    ParsedReq req;
+    int ret;
+    char keyIdBuf[256];
+    word32 keyIdSz = sizeof(keyIdBuf);
+
+    ret = recv_request(fd, buf, sizeof(buf));
+    if (ret <= 0) return -1;
+
+    printf("[Server] --- New request ---\n");
+
+    ret = parse_request(buf, &req);
+    if (ret != 0) {
+        printf("[Server] Failed to parse request\n");
+        send_response(fd, 400, "Bad Request", "Malformed request\n");
+        return -1;
+    }
+
+    printf("[Server] %s %s%s (Host: %s)\n",
+           req.method, req.path, req.query, req.authority);
+
+    if (!req.hasSig || !req.hasSigInput) {
+        printf("[Server] Missing Signature or Signature-Input header\n");
+        send_response(fd, 400, "Bad Request",
+                      "Missing Signature or Signature-Input header\n");
+        return -1;
+    }
+
+    ret = wc_HttpSig_GetKeyId(req.sigInput, NULL, keyIdBuf, &keyIdSz);
+    if (ret != 0) {
+        printf("[Server] Failed to extract keyid: %d\n", ret);
+        send_response(fd, 400, "Bad Request", "Cannot extract keyid\n");
+        return -1;
+    }
+
+    printf("[Server] Extracted keyid: \"%s\"\n", keyIdBuf);
+
+    if (strcmp(keyIdBuf, kDemoKeyId) != 0) {
+        printf("[Server] Unknown keyid → 401\n");
+        send_response(fd, 401, "Unauthorized", "Unknown key\n");
+        return 0;
+    }
+
+    ret = wc_HttpSig_Verify(
+        req.method,
+        req.authority,
+        req.path,
+        req.query[0] ? req.query : NULL,
+        req.hdrs, req.hdrCount,
+        req.sig,
+        req.sigInput,
+        NULL,
+        pubKey,
+        300
+    );
+
+    if (ret == 0) {
+        printf("[Server] Signature VALID → 200 OK\n");
+        send_response(fd, 200, "OK", "Signature verified\n");
+    } else {
+        printf("[Server] Signature INVALID (%d: %s) → 401\n",
+               ret, wc_GetErrorString(ret));
+        send_response(fd, 401, "Unauthorized", "Invalid signature\n");
+    }
+
+    return 0;
+}
+
+int main(void)
+{
+    int listenFd, clientFd, ret, opt = 1;
+    struct sockaddr_in addr;
+    ed25519_key pubKey;
+
+    struct sigaction sa;
+
+    setbuf(stdout, NULL);
+
+    memset(&sa, 0, sizeof(sa));
+    sa.sa_handler = on_signal;
+    sigemptyset(&sa.sa_mask);
+    sa.sa_flags = 0; /* no SA_RESTART so accept() returns EINTR */
+    sigaction(SIGINT, &sa, NULL);
+
+    signal(SIGPIPE, SIG_IGN);
+
+    ret = wc_ed25519_init(&pubKey);
+    if (ret != 0) {
+        printf("Failed to init public key: %d\n", ret);
+        return 1;
+    }
+    ret = wc_ed25519_import_public(kDemoPubKey, ED25519_PUB_KEY_SIZE, &pubKey);
+    if (ret != 0) {
+        printf("Failed to import public key: %d\n", ret);
+        return 1;
+    }
+
+    listenFd = socket(AF_INET, SOCK_STREAM, 0);
+    if (listenFd < 0) { perror("socket"); return 1; }
+
+    setsockopt(listenFd, SOL_SOCKET, SO_REUSEADDR, &opt, sizeof(opt));
+
+    memset(&addr, 0, sizeof(addr));
+    addr.sin_family = AF_INET;
+    addr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+    addr.sin_port = htons(LISTEN_PORT);
+
+    if (bind(listenFd, (struct sockaddr*)&addr, sizeof(addr)) < 0) {
+        perror("bind");
+        close(listenFd);
+        return 1;
+    }
+
+    if (listen(listenFd, 5) < 0) {
+        perror("listen");
+        close(listenFd);
+        return 1;
+    }
+
+    printf("[Server] Listening on localhost:%d (Ctrl-C to stop)\n",
+           LISTEN_PORT);
+    printf("[Server] Accepting keyid: \"%s\"\n\n", kDemoKeyId);
+
+    while (g_running) {
+        clientFd = accept(listenFd, NULL, NULL);
+        if (clientFd < 0) continue;
+        handle_request(clientFd, &pubKey);
+        close(clientFd);
+        printf("\n");
+    }
+
+    printf("[Server] Shutting down\n");
+    close(listenFd);
+    wc_ed25519_free(&pubKey);
+    return 0;
+}
+
+#else
+
+int main(void)
+{
+    printf("This example requires wolfSSL compiled with --enable-ed25519\n");
+    return 1;
+}
+
+#endif

--- a/http-message-signatures/http_server_verify.c
+++ b/http-message-signatures/http_server_verify.c
@@ -298,7 +298,9 @@ static int handle_request(int fd, ed25519_key* pubKey)
 
 int main(void)
 {
-    int listenFd, clientFd, ret, opt = 1;
+    int listenFd = -1, clientFd, ret, opt = 1;
+    int pubKeyInited = 0;
+    int rc = 1;
     struct sockaddr_in addr;
     ed25519_key pubKey;
 
@@ -317,16 +319,18 @@ int main(void)
     ret = wc_ed25519_init(&pubKey);
     if (ret != 0) {
         printf("Failed to init public key: %d\n", ret);
-        return 1;
+        goto cleanup;
     }
+    pubKeyInited = 1;
+
     ret = wc_ed25519_import_public(kDemoPubKey, ED25519_PUB_KEY_SIZE, &pubKey);
     if (ret != 0) {
         printf("Failed to import public key: %d\n", ret);
-        return 1;
+        goto cleanup;
     }
 
     listenFd = socket(AF_INET, SOCK_STREAM, 0);
-    if (listenFd < 0) { perror("socket"); return 1; }
+    if (listenFd < 0) { perror("socket"); goto cleanup; }
 
     setsockopt(listenFd, SOL_SOCKET, SO_REUSEADDR, &opt, sizeof(opt));
 
@@ -337,14 +341,12 @@ int main(void)
 
     if (bind(listenFd, (struct sockaddr*)&addr, sizeof(addr)) < 0) {
         perror("bind");
-        close(listenFd);
-        return 1;
+        goto cleanup;
     }
 
     if (listen(listenFd, 5) < 0) {
         perror("listen");
-        close(listenFd);
-        return 1;
+        goto cleanup;
     }
 
     printf("[Server] Listening on localhost:%d (Ctrl-C to stop)\n",
@@ -360,9 +362,14 @@ int main(void)
     }
 
     printf("[Server] Shutting down\n");
-    close(listenFd);
-    wc_ed25519_free(&pubKey);
-    return 0;
+    rc = 0;
+
+cleanup:
+    if (listenFd >= 0)
+        close(listenFd);
+    if (pubKeyInited)
+        wc_ed25519_free(&pubKey);
+    return rc;
 }
 
 #else

--- a/http-message-signatures/sign_request.c
+++ b/http-message-signatures/sign_request.c
@@ -1,0 +1,150 @@
+/* sign_request.c
+ *
+ * Example: Sign an HTTP request using RFC 9421 HTTP Message Signatures
+ * with Ed25519 via wolfCrypt.
+ *
+ * Build wolfSSL with:
+ *   ./configure --enable-ed25519 --enable-coding && make && sudo make install
+ *
+ * Copyright (C) 2006-2026 wolfSSL Inc.
+ *
+ * This file is part of wolfSSL.
+ *
+ * wolfSSL is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * wolfSSL is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
+ */
+
+#ifndef WOLFSSL_USER_SETTINGS
+    #include <wolfssl/options.h>
+#endif
+#include <wolfssl/wolfcrypt/settings.h>
+#include <wolfssl/wolfcrypt/ed25519.h>
+#include <wolfssl/wolfcrypt/random.h>
+#include <wolfssl/wolfcrypt/error-crypt.h>
+
+#include <stdio.h>
+#include <string.h>
+
+#include "common/wc_http_sig.h"
+
+#if defined(HAVE_ED25519) && defined(HAVE_ED25519_SIGN)
+
+int main(void)
+{
+    int ret;
+    ed25519_key key;
+    WC_RNG rng;
+    char sigBuf[512];
+    word32 sigBufSz = sizeof(sigBuf);
+    char inputBuf[1024];
+    word32 inputBufSz = sizeof(inputBuf);
+
+    /* Request to sign */
+    const char* method    = "POST";
+    const char* authority = "example.com";
+    const char* path      = "/api/resource";
+    const char* query     = "?action=update";
+    const char* keyId     = "my-agent-key-1";
+
+    /* Additional headers to include in the signature */
+    wc_HttpHeader headers[2];
+    headers[0].name  = "content-type";
+    headers[0].value = "application/json";
+    headers[1].name  = "date";
+    headers[1].value = "Thu, 19 Mar 2026 12:00:00 GMT";
+
+    printf("=== RFC 9421 HTTP Message Signature - Sign Example ===\n\n");
+
+    /* Initialize RNG and generate Ed25519 key */
+    ret = wc_InitRng(&rng);
+    if (ret != 0) {
+        printf("RNG init failed: %d\n", ret);
+        return 1;
+    }
+
+    ret = wc_ed25519_init(&key);
+    if (ret != 0) {
+        printf("Ed25519 init failed: %d\n", ret);
+        wc_FreeRng(&rng);
+        return 1;
+    }
+
+    ret = wc_ed25519_make_key(&rng, ED25519_KEY_SIZE, &key);
+    if (ret != 0) {
+        printf("Key generation failed: %d\n", ret);
+        goto cleanup;
+    }
+
+    printf("Request:\n");
+    printf("  %s %s%s HTTP/1.1\n", method, path, query);
+    printf("  Host: %s\n", authority);
+    printf("  Content-Type: %s\n", headers[0].value);
+    printf("  Date: %s\n\n", headers[1].value);
+
+    /* Sign the request */
+    ret = wc_HttpSig_Sign(
+        method, authority, path, query,
+        headers, 2,
+        &key, keyId,
+        0,  /* use current time */
+        sigBuf, &sigBufSz,
+        inputBuf, &inputBufSz
+    );
+
+    if (ret != 0) {
+        printf("Signing failed: %d (%s)\n", ret, wc_GetErrorString(ret));
+        goto cleanup;
+    }
+
+    printf("Signed headers to add to request:\n\n");
+    printf("  Signature-Input: %.*s\n", (int)inputBufSz, inputBuf);
+    printf("  Signature: %.*s\n\n", (int)sigBufSz, sigBuf);
+
+    /* Export public key so verifier can use it */
+    {
+        byte pubKeyBuf[ED25519_PUB_KEY_SIZE];
+        word32 pubKeySz = sizeof(pubKeyBuf);
+        int i;
+
+        ret = wc_ed25519_export_public(&key, pubKeyBuf, &pubKeySz);
+        if (ret == 0) {
+            printf("Public key (hex, %d bytes):\n  ", pubKeySz);
+            for (i = 0; i < (int)pubKeySz; i++)
+                printf("%02x", pubKeyBuf[i]);
+            printf("\n\n");
+        }
+    }
+
+    printf("Success\n");
+
+cleanup:
+    wc_ed25519_free(&key);
+    wc_FreeRng(&rng);
+
+    if (ret != 0) {
+        printf("Error: %d (%s)\n", ret, wc_GetErrorString(ret));
+        return 1;
+    }
+    return 0;
+}
+
+#else
+
+int main(void)
+{
+    printf("This example requires wolfSSL compiled with --enable-ed25519\n");
+    return 1;
+}
+
+#endif /* HAVE_ED25519 */

--- a/http-message-signatures/test_vectors.c
+++ b/http-message-signatures/test_vectors.c
@@ -177,6 +177,8 @@ static int sign_verify_roundtrip_ex(
     int ret;
     ed25519_key key, verifyKey;
     WC_RNG rng;
+    int keyInited = 0;
+    int verifyKeyInited = 0;
     char sigBuf[512];
     word32 sigBufSz = sizeof(sigBuf);
     char inputBuf[1024];
@@ -187,8 +189,10 @@ static int sign_verify_roundtrip_ex(
 
     ret = wc_ed25519_init(&key);
     if (ret != 0) goto done;
+    keyInited = 1;
     ret = wc_ed25519_init(&verifyKey);
     if (ret != 0) goto done;
+    verifyKeyInited = 1;
 
     ret = wc_ed25519_make_key(&rng, ED25519_KEY_SIZE, &key);
     if (ret != 0) goto done;
@@ -218,8 +222,10 @@ static int sign_verify_roundtrip_ex(
         NULL, &verifyKey, maxAgeSec);
 
 done:
-    wc_ed25519_free(&key);
-    wc_ed25519_free(&verifyKey);
+    if (keyInited)
+        wc_ed25519_free(&key);
+    if (verifyKeyInited)
+        wc_ed25519_free(&verifyKey);
     wc_FreeRng(&rng);
     return ret;
 }

--- a/http-message-signatures/test_vectors.c
+++ b/http-message-signatures/test_vectors.c
@@ -1,0 +1,1175 @@
+/* test_vectors.c
+ *
+ * Validates the implementation against RFC 9421 Appendix B.2.6
+ * (Signing a Request Using ed25519) and performs a round-trip test.
+ *
+ * Test data from:
+ *   https://www.rfc-editor.org/rfc/rfc9421#appendix-B.1.4  (Ed25519 key)
+ *   https://www.rfc-editor.org/rfc/rfc9421#appendix-B.2.6  (test case)
+ *
+ * Build wolfSSL with:
+ *   ./configure --enable-ed25519 --enable-coding && make && sudo make install
+ *
+ * Copyright (C) 2006-2026 wolfSSL Inc.
+ *
+ * This file is part of wolfSSL.
+ *
+ * wolfSSL is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * wolfSSL is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
+ */
+
+#ifndef WOLFSSL_USER_SETTINGS
+    #include <wolfssl/options.h>
+#endif
+#include <wolfssl/wolfcrypt/settings.h>
+#include <wolfssl/wolfcrypt/ed25519.h>
+#include <wolfssl/wolfcrypt/coding.h>
+#include <wolfssl/wolfcrypt/error-crypt.h>
+
+#include <stdio.h>
+#include <string.h>
+
+#include "common/wc_http_sig.h"
+#include "common/wc_sf.h"
+
+#if defined(HAVE_ED25519) && defined(HAVE_ED25519_SIGN) && \
+    defined(HAVE_ED25519_VERIFY)
+
+/* --- RFC 9421 Appendix B.1.4 - Ed25519 test key (raw bytes) --- */
+
+static const byte kTestPrivKey[ED25519_KEY_SIZE] = {
+    0x9f, 0x83, 0x62, 0xf8, 0x7a, 0x48, 0x4a, 0x95,
+    0x4e, 0x6e, 0x74, 0x0c, 0x5b, 0x4c, 0x0e, 0x84,
+    0x22, 0x91, 0x39, 0xa2, 0x0a, 0xa8, 0xab, 0x56,
+    0xff, 0x66, 0x58, 0x6f, 0x6a, 0x7d, 0x29, 0xc5
+};
+
+static const byte kTestPubKey[ED25519_PUB_KEY_SIZE] = {
+    0x26, 0xb4, 0x0b, 0x8f, 0x93, 0xff, 0xf3, 0xd8,
+    0x97, 0x11, 0x2f, 0x7e, 0xbc, 0x58, 0x2b, 0x23,
+    0x2d, 0xbd, 0x72, 0x51, 0x7d, 0x08, 0x2f, 0xe8,
+    0x3c, 0xfb, 0x30, 0xdd, 0xce, 0x43, 0xd1, 0xbb
+};
+
+/* --- RFC 9421 Appendix B.2 - Test request components --- */
+
+static const char* kMethod    = "POST";
+static const char* kAuthority = "example.com";
+static const char* kPath      = "/foo";
+
+static const wc_HttpHeader kHeaders[] = {
+    { "date",           "Tue, 20 Apr 2021 02:07:55 GMT" },
+    { "content-type",   "application/json" },
+    { "content-length", "18" }
+};
+
+/* RFC 9421 Appendix B.2.6 expected signature base */
+static const char kExpectedSigBase[] =
+    "\"date\": Tue, 20 Apr 2021 02:07:55 GMT\n"
+    "\"@method\": POST\n"
+    "\"@path\": /foo\n"
+    "\"@authority\": example.com\n"
+    "\"content-type\": application/json\n"
+    "\"content-length\": 18\n"
+    "\"@signature-params\": (\"date\" \"@method\" \"@path\" \"@authority\" "
+    "\"content-type\" \"content-length\")"
+    ";created=1618884473;keyid=\"test-key-ed25519\"";
+
+/* Expected signature (base64) from RFC 9421 B.2.6 */
+static const char kExpectedSigB64[] =
+    "wqcAqbmYJ2ji2glfAMaRy4gruYYnx2nEFN2HN6jrnDnQCK1u"
+    "02Gb04v9EDgwUPiu4A0w6vuQv5lIp5WPpBKRCw==";
+
+static const char kExpectedSigInput[] =
+    "sig1=(\"date\" \"@method\" \"@path\" \"@authority\" "
+    "\"content-type\" \"content-length\")"
+    ";created=1618884473;keyid=\"test-key-ed25519\"";
+
+/* --- Helpers --- */
+
+static const char* kB26Components[] = {
+    "date", "@method", "@path", "@authority",
+    "content-type", "content-length"
+};
+static const int kB26CompCount = 6;
+static const char kB26SigParamsVal[] =
+    "(\"date\" \"@method\" \"@path\" \"@authority\" "
+    "\"content-type\" \"content-length\")"
+    ";created=1618884473;keyid=\"test-key-ed25519\"";
+
+static int build_rfc_b26_sig_base(byte* out, word32* outSz)
+{
+    int pos = 0, n, i;
+    int maxSz = (int)*outSz;
+
+    for (i = 0; i < kB26CompCount; i++) {
+        const char* val = NULL;
+
+        if (strcmp(kB26Components[i], "@method") == 0)
+            val = kMethod;
+        else if (strcmp(kB26Components[i], "@authority") == 0)
+            val = kAuthority;
+        else if (strcmp(kB26Components[i], "@path") == 0)
+            val = kPath;
+        else {
+            int j;
+            for (j = 0; j < (int)(sizeof(kHeaders)/sizeof(kHeaders[0])); j++) {
+                if (strcmp(kHeaders[j].name, kB26Components[i]) == 0) {
+                    val = kHeaders[j].value;
+                    break;
+                }
+            }
+        }
+
+        if (!val) return -1;
+        n = snprintf((char*)out + pos, maxSz - pos,
+                     "\"%s\": %s\n", kB26Components[i], val);
+        if (n < 0 || n >= maxSz - pos) return -1;
+        pos += n;
+    }
+
+    n = snprintf((char*)out + pos, maxSz - pos,
+                 "\"@signature-params\": %s", kB26SigParamsVal);
+    if (n < 0 || n >= maxSz - pos) return -1;
+    pos += n;
+    *outSz = (word32)pos;
+    return 0;
+}
+
+static int sign_verify_roundtrip_ex(
+    const char* method, const char* authority,
+    const char* path, const char* query,
+    const wc_HttpHeader* signHdrs, int signHdrCount,
+    const wc_HttpHeader* verifyHdrs, int verifyHdrCount,
+    const char* keyId, long created, int maxAgeSec);
+
+static int sign_verify_roundtrip(
+    const char* method, const char* authority,
+    const char* path, const char* query,
+    const wc_HttpHeader* signHdrs, int signHdrCount,
+    const wc_HttpHeader* verifyHdrs, int verifyHdrCount,
+    const char* keyId)
+{
+    return sign_verify_roundtrip_ex(method, authority, path, query,
+                                    signHdrs, signHdrCount,
+                                    verifyHdrs, verifyHdrCount,
+                                    keyId, 1700000000, 0);
+}
+
+static int sign_verify_roundtrip_ex(
+    const char* method, const char* authority,
+    const char* path, const char* query,
+    const wc_HttpHeader* signHdrs, int signHdrCount,
+    const wc_HttpHeader* verifyHdrs, int verifyHdrCount,
+    const char* keyId, long created, int maxAgeSec)
+{
+    int ret;
+    ed25519_key key, verifyKey;
+    WC_RNG rng;
+    char sigBuf[512];
+    word32 sigBufSz = sizeof(sigBuf);
+    char inputBuf[1024];
+    word32 inputBufSz = sizeof(inputBuf);
+
+    ret = wc_InitRng(&rng);
+    if (ret != 0) return ret;
+
+    ret = wc_ed25519_init(&key);
+    if (ret != 0) goto done;
+    ret = wc_ed25519_init(&verifyKey);
+    if (ret != 0) goto done;
+
+    ret = wc_ed25519_make_key(&rng, ED25519_KEY_SIZE, &key);
+    if (ret != 0) goto done;
+
+    ret = wc_HttpSig_Sign(
+        method, authority, path, query,
+        signHdrs, signHdrCount,
+        &key, keyId, created,
+        sigBuf, &sigBufSz,
+        inputBuf, &inputBufSz);
+    if (ret != 0) goto done;
+
+    {
+        byte pubBuf[ED25519_PUB_KEY_SIZE];
+        word32 pubSz = sizeof(pubBuf);
+        ret = wc_ed25519_export_public(&key, pubBuf, &pubSz);
+        if (ret != 0) goto done;
+        ret = wc_ed25519_import_public(pubBuf, pubSz, &verifyKey);
+        if (ret != 0) goto done;
+    }
+
+    ret = wc_HttpSig_Verify(
+        method, authority, path, query,
+        verifyHdrs ? verifyHdrs : signHdrs,
+        verifyHdrs ? verifyHdrCount : signHdrCount,
+        sigBuf, inputBuf,
+        NULL, &verifyKey, maxAgeSec);
+
+done:
+    wc_ed25519_free(&key);
+    wc_ed25519_free(&verifyKey);
+    wc_FreeRng(&rng);
+    return ret;
+}
+
+/* --- Test 1: Structured Fields round-trip --- */
+
+static int test_sf_roundtrip(void)
+{
+    int ret;
+    wc_SfSigInput parsed;
+    char generated[1024];
+    word32 genSz = sizeof(generated);
+
+    printf("Test 1: Structured Fields parse/generate round-trip\n");
+
+    ret = wc_SfParseSigInput(kExpectedSigInput, "sig1", &parsed);
+    if (ret != 0) { printf("  FAIL: parse returned %d\n", ret); return ret; }
+
+    if (parsed.itemCount != 6) {
+        printf("  FAIL: expected 6 items, got %d\n", parsed.itemCount);
+        return -1;
+    }
+
+    if (strcmp(parsed.items[0], "date") != 0 ||
+        strcmp(parsed.items[1], "@method") != 0) {
+        printf("  FAIL: unexpected item values\n");
+        return -1;
+    }
+
+    ret = wc_SfGenSigInput(&parsed, generated, &genSz);
+    if (ret != 0) { printf("  FAIL: generate returned %d\n", ret); return ret; }
+
+    if (strcmp(generated, kExpectedSigInput) != 0) {
+        printf("  FAIL: round-trip mismatch\n");
+        printf("  Expected: %s\n", kExpectedSigInput);
+        printf("  Got:      %s\n", generated);
+        return -1;
+    }
+
+    printf("  PASS\n");
+    return 0;
+}
+
+/* --- Test 2: Signature base construction matches RFC B.2.6 --- */
+
+static int test_signature_base(void)
+{
+    byte buf[4096];
+    word32 bufSz = sizeof(buf);
+
+    printf("Test 2: Signature base construction\n");
+
+    if (build_rfc_b26_sig_base(buf, &bufSz) != 0) {
+        printf("  FAIL: could not build signature base\n");
+        return -1;
+    }
+
+    if (bufSz != (word32)strlen(kExpectedSigBase) ||
+        memcmp(buf, kExpectedSigBase, bufSz) != 0) {
+        printf("  FAIL: signature base mismatch\n");
+        return -1;
+    }
+
+    printf("  PASS\n");
+    return 0;
+}
+
+/* --- Test 3: RFC 9421 B.2.6 - Ed25519 sign + verify with RFC key --- */
+
+static int test_rfc_vector_verify(void)
+{
+    int ret, verifyRes = 0, i;
+    ed25519_key key;
+    byte producedSig[ED25519_SIG_SIZE];
+    word32 producedSigSz = sizeof(producedSig);
+    byte expectedSig[ED25519_SIG_SIZE];
+    word32 expectedSigSz = sizeof(expectedSig);
+    byte sigBase[4096];
+    word32 sigBaseSz = sizeof(sigBase);
+
+    printf("Test 3: RFC 9421 B.2.6 Ed25519 vector - sign + verify\n");
+
+    ret = Base64_Decode((const byte*)kExpectedSigB64,
+                        (word32)strlen(kExpectedSigB64),
+                        expectedSig, &expectedSigSz);
+    if (ret != 0) { printf("  FAIL: base64 decode: %d\n", ret); return ret; }
+
+    if (build_rfc_b26_sig_base(sigBase, &sigBaseSz) != 0) {
+        printf("  FAIL: could not build signature base\n");
+        return -1;
+    }
+
+    if (sigBaseSz != (word32)strlen(kExpectedSigBase) ||
+        memcmp(sigBase, kExpectedSigBase, sigBaseSz) != 0) {
+        printf("  FAIL: signature base mismatch\n");
+        return -1;
+    }
+    printf("  Signature base matches RFC expected value\n");
+
+    /* Import RFC private key seed, derive public, re-import as full keypair */
+    ret = wc_ed25519_init(&key);
+    if (ret != 0) return ret;
+
+    ret = wc_ed25519_import_private_only(kTestPrivKey, ED25519_KEY_SIZE, &key);
+    if (ret != 0) {
+        printf("  FAIL: import private seed: %d\n", ret);
+        wc_ed25519_free(&key);
+        return ret;
+    }
+
+    {
+        byte derivedPub[ED25519_PUB_KEY_SIZE];
+        word32 derivedPubSz = ED25519_PUB_KEY_SIZE;
+        ret = wc_ed25519_make_public(&key, derivedPub, derivedPubSz);
+        if (ret != 0) {
+            printf("  FAIL: make public: %d\n", ret);
+            wc_ed25519_free(&key);
+            return ret;
+        }
+
+        if (memcmp(derivedPub, kTestPubKey, ED25519_PUB_KEY_SIZE) != 0) {
+            printf("  WARNING: derived pubkey differs from RFC pubkey\n");
+        }
+
+        ret = wc_ed25519_import_private_key(kTestPrivKey, ED25519_KEY_SIZE,
+                                            derivedPub, derivedPubSz, &key);
+        if (ret != 0) {
+            printf("  FAIL: import keypair: %d\n", ret);
+            wc_ed25519_free(&key);
+            return ret;
+        }
+    }
+
+    ret = wc_ed25519_sign_msg(sigBase, sigBaseSz,
+                              producedSig, &producedSigSz, &key);
+    if (ret != 0) {
+        printf("  FAIL: sign returned %d\n", ret);
+        wc_ed25519_free(&key);
+        return ret;
+    }
+
+    if (producedSigSz != expectedSigSz ||
+        memcmp(producedSig, expectedSig, producedSigSz) != 0) {
+        printf("  FAIL: produced signature != RFC expected signature\n");
+        printf("  Produced: ");
+        for (i = 0; i < (int)producedSigSz; i++) printf("%02x", producedSig[i]);
+        printf("\n  Expected: ");
+        for (i = 0; i < (int)expectedSigSz; i++) printf("%02x", expectedSig[i]);
+        printf("\n");
+        wc_ed25519_free(&key);
+        return SIG_VERIFY_E;
+    }
+    printf("  Produced signature matches RFC B.2.6 expected value\n");
+
+    ret = wc_ed25519_verify_msg(producedSig, producedSigSz,
+                                sigBase, sigBaseSz, &verifyRes, &key);
+    wc_ed25519_free(&key);
+
+    if (ret != 0) {
+        printf("  FAIL: verify returned %d\n", ret);
+        return ret;
+    }
+    if (verifyRes != 1) {
+        printf("  FAIL: verification failed\n");
+        return SIG_VERIFY_E;
+    }
+
+    printf("  PASS\n");
+    return 0;
+}
+
+/* --- Test 4: Full sign/verify round-trip --- */
+
+static int test_api_roundtrip(void)
+{
+    int ret;
+    wc_HttpHeader headers[2];
+    headers[0].name  = "content-type";
+    headers[0].value = "application/json";
+    headers[1].name  = "date";
+    headers[1].value = "Thu, 19 Mar 2026 12:00:00 GMT";
+
+    printf("Test 4: Full API sign/verify round-trip\n");
+
+    ret = sign_verify_roundtrip(
+        "POST", "example.com", "/api/data", "?v=1",
+        headers, 2, NULL, 0, "round-trip-key");
+    if (ret != 0)
+        printf("  FAIL: %d (%s)\n", ret, wc_GetErrorString(ret));
+    else
+        printf("  PASS\n");
+    return ret;
+}
+
+/* --- Test 5: GetKeyId extraction --- */
+
+static int test_get_keyid(void)
+{
+    int ret;
+    char keyIdBuf[256];
+    word32 keyIdSz = sizeof(keyIdBuf);
+
+    printf("Test 5: GetKeyId extraction\n");
+
+    ret = wc_HttpSig_GetKeyId(kExpectedSigInput, "sig1", keyIdBuf, &keyIdSz);
+    if (ret != 0) { printf("  FAIL: returned %d\n", ret); return ret; }
+
+    if (strcmp(keyIdBuf, "test-key-ed25519") != 0) {
+        printf("  FAIL: expected 'test-key-ed25519', got '%s'\n", keyIdBuf);
+        return -1;
+    }
+
+    printf("  PASS\n");
+    return 0;
+}
+
+/* --- Test 6: Sign/verify with @query component --- */
+
+static int test_query_component(void)
+{
+    int ret;
+    ed25519_key key, verifyKey;
+    WC_RNG rng;
+    char sigBuf[512];
+    word32 sigBufSz = sizeof(sigBuf);
+    char inputBuf[1024];
+    word32 inputBufSz = sizeof(inputBuf);
+
+    wc_HttpHeader headers[1];
+    headers[0].name  = "date";
+    headers[0].value = "Thu, 19 Mar 2026 12:00:00 GMT";
+
+    printf("Test 6: Sign/verify with @query component\n");
+
+    ret = wc_InitRng(&rng);
+    if (ret != 0) return ret;
+    ret = wc_ed25519_init(&key);
+    if (ret != 0) { wc_FreeRng(&rng); return ret; }
+    ret = wc_ed25519_init(&verifyKey);
+    if (ret != 0) { wc_ed25519_free(&key); wc_FreeRng(&rng); return ret; }
+
+    ret = wc_ed25519_make_key(&rng, ED25519_KEY_SIZE, &key);
+    if (ret != 0) goto cleanup6;
+
+    ret = wc_HttpSig_Sign(
+        "GET", "api.example.com", "/search", "?q=test&page=2",
+        headers, 1, &key, "query-test-key", 1700000000,
+        sigBuf, &sigBufSz, inputBuf, &inputBufSz);
+    if (ret != 0) { printf("  FAIL: sign returned %d\n", ret); goto cleanup6; }
+
+    if (strstr(inputBuf, "\"@query\"") == NULL) {
+        printf("  FAIL: @query not found in Signature-Input\n");
+        ret = -1;
+        goto cleanup6;
+    }
+
+    {
+        byte pubBuf[ED25519_PUB_KEY_SIZE];
+        word32 pubSz = sizeof(pubBuf);
+        ret = wc_ed25519_export_public(&key, pubBuf, &pubSz);
+        if (ret != 0) goto cleanup6;
+        ret = wc_ed25519_import_public(pubBuf, pubSz, &verifyKey);
+        if (ret != 0) goto cleanup6;
+    }
+
+    ret = wc_HttpSig_Verify(
+        "GET", "api.example.com", "/search", "?q=test&page=2",
+        headers, 1, sigBuf, inputBuf,
+        NULL, &verifyKey, 0);
+    if (ret != 0) {
+        printf("  FAIL: verify returned %d\n", ret);
+        goto cleanup6;
+    }
+
+    /* Negative: wrong query should fail */
+    ret = wc_HttpSig_Verify(
+        "GET", "api.example.com", "/search", "?q=different",
+        headers, 1, sigBuf, inputBuf,
+        NULL, &verifyKey, 0);
+    if (ret == 0) {
+        printf("  FAIL: tampered query was accepted\n");
+        ret = -1;
+        goto cleanup6;
+    }
+
+    ret = 0;
+    printf("  PASS\n");
+
+cleanup6:
+    wc_ed25519_free(&key);
+    wc_ed25519_free(&verifyKey);
+    wc_FreeRng(&rng);
+    return ret;
+}
+
+/* --- Test 7: Case-insensitive headers + whitespace trimming --- */
+
+static int test_header_normalization(void)
+{
+    int ret;
+    wc_HttpHeader signHdrs[2];
+    wc_HttpHeader verifyHdrs[2];
+
+    signHdrs[0].name  = "content-type";
+    signHdrs[0].value = "application/json";
+    signHdrs[1].name  = "x-custom";
+    signHdrs[1].value = "hello";
+
+    verifyHdrs[0].name  = "Content-Type";
+    verifyHdrs[0].value = "  application/json  ";
+    verifyHdrs[1].name  = "X-Custom";
+    verifyHdrs[1].value = "\thello\t";
+
+    printf("Test 7: Case-insensitive headers + whitespace trimming\n");
+
+    ret = sign_verify_roundtrip(
+        "POST", "example.com", "/api", NULL,
+        signHdrs, 2, verifyHdrs, 2, "norm-test");
+    if (ret != 0)
+        printf("  FAIL: verify with normalized headers returned %d\n", ret);
+    else
+        printf("  PASS\n");
+    return ret;
+}
+
+/* --- Test 8: Algorithm enforcement --- */
+
+static int test_alg_enforcement(void)
+{
+    int ret;
+    wc_SfSigInput sfIn;
+    char fakeInput[512];
+    word32 fakeInputSz;
+    ed25519_key key;
+    WC_RNG rng;
+    char sigBuf[512];
+    word32 sigBufSz = sizeof(sigBuf);
+    char realInputBuf[1024];
+    word32 realInputBufSz = sizeof(realInputBuf);
+
+    wc_HttpHeader headers[1];
+    headers[0].name  = "date";
+    headers[0].value = "Thu, 19 Mar 2026 12:00:00 GMT";
+
+    printf("Test 8: Algorithm enforcement\n");
+
+    ret = wc_InitRng(&rng);
+    if (ret != 0) return ret;
+    ret = wc_ed25519_init(&key);
+    if (ret != 0) { wc_FreeRng(&rng); return ret; }
+
+    ret = wc_ed25519_make_key(&rng, ED25519_KEY_SIZE, &key);
+    if (ret != 0) goto cleanup8;
+
+    ret = wc_HttpSig_Sign(
+        "GET", "example.com", "/test", NULL,
+        headers, 1, &key, "alg-test", 1700000000,
+        sigBuf, &sigBufSz, realInputBuf, &realInputBufSz);
+    if (ret != 0) { printf("  FAIL: sign returned %d\n", ret); goto cleanup8; }
+
+    /* Craft Signature-Input with alg="hmac-sha256" */
+    memset(&sfIn, 0, sizeof(sfIn));
+    strncpy(sfIn.label, "sig1", WC_SF_MAX_LABEL - 1);
+    strncpy(sfIn.items[0], "@method", WC_SF_MAX_STRING - 1);
+    strncpy(sfIn.items[1], "@authority", WC_SF_MAX_STRING - 1);
+    strncpy(sfIn.items[2], "@path", WC_SF_MAX_STRING - 1);
+    strncpy(sfIn.items[3], "date", WC_SF_MAX_STRING - 1);
+    sfIn.itemCount = 4;
+
+    strncpy(sfIn.params[0].name, "created", WC_SF_MAX_LABEL - 1);
+    sfIn.params[0].type = WC_SF_PARAM_INTEGER;
+    sfIn.params[0].intVal = 1700000000;
+    strncpy(sfIn.params[1].name, "keyid", WC_SF_MAX_LABEL - 1);
+    sfIn.params[1].type = WC_SF_PARAM_STRING;
+    strncpy(sfIn.params[1].strVal, "alg-test", WC_SF_MAX_STRING - 1);
+    strncpy(sfIn.params[2].name, "alg", WC_SF_MAX_LABEL - 1);
+    sfIn.params[2].type = WC_SF_PARAM_STRING;
+    strncpy(sfIn.params[2].strVal, "hmac-sha256", WC_SF_MAX_STRING - 1);
+    sfIn.paramCount = 3;
+
+    fakeInputSz = sizeof(fakeInput);
+    ret = wc_SfGenSigInput(&sfIn, fakeInput, &fakeInputSz);
+    if (ret != 0) {
+        printf("  FAIL: gen fake input: %d\n", ret);
+        goto cleanup8;
+    }
+
+    ret = wc_HttpSig_Verify(
+        "GET", "example.com", "/test", NULL,
+        headers, 1, sigBuf, fakeInput,
+        NULL, &key, 0);
+    if (ret == 0) {
+        printf("  FAIL: wrong alg was accepted\n");
+        ret = -1;
+        goto cleanup8;
+    }
+
+    ret = 0;
+    printf("  PASS\n");
+
+cleanup8:
+    wc_ed25519_free(&key);
+    wc_FreeRng(&rng);
+    return ret;
+}
+
+/* --- Test 9: Timestamp validation (maxAgeSec) --- */
+
+static int test_timestamp_validation(void)
+{
+    int ret;
+    wc_HttpHeader headers[1];
+    headers[0].name  = "date";
+    headers[0].value = "Thu, 19 Mar 2026 12:00:00 GMT";
+
+    printf("Test 9: Timestamp validation (maxAgeSec)\n");
+
+    /* Sign with old timestamp (~2001), maxAgeSec=300 -> fail */
+    ret = sign_verify_roundtrip_ex(
+        "GET", "example.com", "/ts-test", NULL,
+        headers, 1, NULL, 0, "ts-key", 1000000000L, 300);
+    if (ret == 0) {
+        printf("  FAIL: expired signature was accepted\n");
+        return -1;
+    }
+
+    /* Same old timestamp, verify with maxAgeSec=0 (skip) → succeed */
+    ret = sign_verify_roundtrip_ex(
+        "GET", "example.com", "/ts-test", NULL,
+        headers, 1, NULL, 0, "ts-key", 1000000000L, 0);
+    if (ret != 0) {
+        printf("  FAIL: maxAgeSec=0 should skip check, got %d\n", ret);
+        return ret;
+    }
+
+    printf("  PASS\n");
+    return 0;
+}
+
+/* --- Test 10: Auto-timestamp (created=0) with maxAgeSec --- */
+
+static int test_auto_timestamp(void)
+{
+    int ret;
+    wc_HttpHeader headers[1];
+    headers[0].name  = "date";
+    headers[0].value = "Thu, 19 Mar 2026 12:00:00 GMT";
+
+    printf("Test 10: Auto-timestamp (created=0) with maxAgeSec\n");
+
+    /* Sign with created=0 (auto), verify with maxAgeSec=60 → succeed */
+    ret = sign_verify_roundtrip_ex(
+        "GET", "example.com", "/auto-ts", NULL,
+        headers, 1, NULL, 0, "auto-key", 0, 60);
+    if (ret != 0) {
+        printf("  FAIL: auto-timestamp + maxAgeSec=60 returned %d\n", ret);
+        return ret;
+    }
+
+    printf("  PASS\n");
+    return 0;
+}
+
+/* --- Test 11: API argument validation --- */
+
+static int test_arg_validation(void)
+{
+    int ret;
+    char sigBuf[512];
+    word32 sigBufSz = sizeof(sigBuf);
+    char inputBuf[1024];
+    word32 inputBufSz = sizeof(inputBuf);
+    ed25519_key key;
+    WC_RNG rng;
+    int pass = 1;
+
+    printf("Test 11: API argument validation\n");
+
+    ret = wc_ed25519_init(&key);
+    if (ret != 0) { printf("  FAIL: ed25519 init\n"); return ret; }
+    ret = wc_InitRng(&rng);
+    if (ret != 0) { printf("  FAIL: RNG init\n"); wc_ed25519_free(&key); return ret; }
+    ret = wc_ed25519_make_key(&rng, ED25519_KEY_SIZE, &key);
+    if (ret != 0) { printf("  FAIL: keygen\n"); wc_FreeRng(&rng); return ret; }
+
+    /* NULL method → BAD_FUNC_ARG */
+    ret = wc_HttpSig_Sign(NULL, "example.com", "/", NULL,
+                          NULL, 0, &key, "k", 1700000000,
+                          sigBuf, &sigBufSz, inputBuf, &inputBufSz);
+    if (ret != BAD_FUNC_ARG) {
+        printf("  FAIL: NULL method accepted (ret=%d)\n", ret);
+        pass = 0;
+    }
+
+    /* headerCount > 0 with NULL headers → BAD_FUNC_ARG */
+    ret = wc_HttpSig_Sign("GET", "example.com", "/", NULL,
+                          NULL, 3, &key, "k", 1700000000,
+                          sigBuf, &sigBufSz, inputBuf, &inputBufSz);
+    if (ret != BAD_FUNC_ARG) {
+        printf("  FAIL: NULL headers with count=3 accepted (ret=%d)\n", ret);
+        pass = 0;
+    }
+
+    /* NULL signatureInput to GetKeyId → BAD_FUNC_ARG */
+    {
+        char kidBuf[64];
+        word32 kidSz = sizeof(kidBuf);
+        ret = wc_HttpSig_GetKeyId(NULL, "sig1", kidBuf, &kidSz);
+        if (ret != BAD_FUNC_ARG) {
+            printf("  FAIL: NULL input to GetKeyId accepted (ret=%d)\n", ret);
+            pass = 0;
+        }
+    }
+
+    /* NULL signature to Verify → BAD_FUNC_ARG */
+    ret = wc_HttpSig_Verify("GET", "example.com", "/", NULL,
+                            NULL, 0, NULL, "sig1=(...)", NULL, &key, 0);
+    if (ret != BAD_FUNC_ARG) {
+        printf("  FAIL: NULL signature accepted (ret=%d)\n", ret);
+        pass = 0;
+    }
+
+    /* headerCount > 0 with NULL headers to Verify → BAD_FUNC_ARG */
+    ret = wc_HttpSig_Verify("GET", "example.com", "/", NULL,
+                            NULL, 2, "sig1=:AA==:", "sig1=()", NULL, &key, 0);
+    if (ret != BAD_FUNC_ARG) {
+        printf("  FAIL: NULL hdrs count=2 Verify "
+               "accepted (ret=%d)\n", ret);
+        pass = 0;
+    }
+
+    wc_ed25519_free(&key);
+    wc_FreeRng(&rng);
+
+    if (!pass) return -1;
+    printf("  PASS\n");
+    return 0;
+}
+
+/* --- Test 12: sf-integer overflow detection --- */
+
+static int test_sf_integer_overflow(void)
+{
+    int ret;
+    wc_SfSigInput parsed;
+
+    /* 999999999999999 (15 digits) is within RFC 8941 range and fits in
+     * 64-bit long. On 32-bit, it should be rejected as overflow. */
+    const char* bigTimestamp =
+        "sig1=(\"@method\");created=999999999999999;keyid=\"k\"";
+    /* 1700000000 (10 digits) — a current-era UNIX timestamp.
+     * Must parse correctly on both 32-bit and 64-bit. */
+    const char* normalTimestamp =
+        "sig1=(\"@method\");created=1700000000;keyid=\"k\"";
+
+    /* Empty integer: `;created=;` must be rejected (RFC 8941 requires
+     * at least one digit). */
+    const char* emptyInt =
+        "sig1=(\"@method\");created=;keyid=\"k\"";
+
+    printf("Test 12: sf-integer overflow detection\n");
+
+    ret = wc_SfParseSigInput(emptyInt, "sig1", &parsed);
+    if (ret == 0) {
+        printf("  FAIL: empty integer value accepted\n");
+        return -1;
+    }
+    printf("  Empty integer correctly rejected\n");
+
+    ret = wc_SfParseSigInput(normalTimestamp, "sig1", &parsed);
+    if (ret != 0) {
+        printf("  FAIL: normal timestamp parse returned %d\n", ret);
+        return -1;
+    }
+    if (parsed.params[0].intVal != 1700000000L) {
+        printf("  FAIL: expected 1700000000, got %ld\n",
+               parsed.params[0].intVal);
+        return -1;
+    }
+
+    if (sizeof(long) <= 4) {
+        ret = wc_SfParseSigInput(bigTimestamp, "sig1", &parsed);
+        if (ret == 0) {
+            printf("  FAIL: 15-digit integer accepted on 32-bit\n");
+            return -1;
+        }
+        printf("  32-bit: large integer correctly rejected\n");
+    } else {
+        ret = wc_SfParseSigInput(bigTimestamp, "sig1", &parsed);
+        if (ret != 0) {
+            printf("  FAIL: 15-digit integer rejected on 64-bit (%d)\n", ret);
+            return -1;
+        }
+        if (parsed.params[0].intVal != 999999999999999L) {
+            printf("  FAIL: 15-digit value mismatch\n");
+            return -1;
+        }
+        printf("  64-bit: large integer correctly parsed\n");
+    }
+
+    printf("  PASS\n");
+    return 0;
+}
+
+/* --- Test 13: find_dict_member with quoted params containing delimiters --- */
+
+static int test_adversarial_sig_input(void)
+{
+    int ret;
+    wc_SfSigInput parsed;
+    char keyIdBuf[256];
+    word32 keyIdSz;
+
+    /* sig1 has a keyid containing ';' and ','. The parser must skip it
+     * correctly to find sig2. */
+    const char* multiDict =
+        "sig1=(\"@method\");keyid=\"a]};,b\";alg=\"ed25519\", "
+        "sig2=(\"@path\");keyid=\"real-key\";alg=\"ed25519\"";
+
+    printf("Test 13: Adversarial Signature-Input (quoted delimiters)\n");
+
+    ret = wc_SfParseSigInput(multiDict, "sig2", &parsed);
+    if (ret != 0) {
+        printf("  FAIL: parse sig2 returned %d\n", ret);
+        return -1;
+    }
+
+    if (parsed.itemCount != 1 || strcmp(parsed.items[0], "@path") != 0) {
+        printf("  FAIL: sig2 items mismatch\n");
+        return -1;
+    }
+
+    keyIdSz = sizeof(keyIdBuf);
+    ret = wc_HttpSig_GetKeyId(multiDict, "sig2", keyIdBuf, &keyIdSz);
+    if (ret != 0) {
+        printf("  FAIL: GetKeyId for sig2 returned %d\n", ret);
+        return -1;
+    }
+    if (strcmp(keyIdBuf, "real-key") != 0) {
+        printf("  FAIL: expected 'real-key', got '%s'\n", keyIdBuf);
+        return -1;
+    }
+
+    printf("  PASS\n");
+    return 0;
+}
+
+/* --- Test 14: sf-string escaping round-trip --- */
+
+static int test_sf_string_escaping(void)
+{
+    int ret;
+    wc_SfSigInput sfIn, parsed;
+    char generated[1024];
+    word32 genSz = sizeof(generated);
+
+    printf("Test 14: sf-string escaping round-trip\n");
+
+    memset(&sfIn, 0, sizeof(sfIn));
+    strncpy(sfIn.label, "sig1", WC_SF_MAX_LABEL - 1);
+    strncpy(sfIn.items[0], "@method", WC_SF_MAX_STRING - 1);
+    sfIn.itemCount = 1;
+
+    strncpy(sfIn.params[0].name, "keyid", WC_SF_MAX_LABEL - 1);
+    sfIn.params[0].type = WC_SF_PARAM_STRING;
+    strncpy(sfIn.params[0].strVal, "key\"with\\quotes",
+            WC_SF_MAX_STRING - 1);
+    sfIn.paramCount = 1;
+
+    ret = wc_SfGenSigInput(&sfIn, generated, &genSz);
+    if (ret != 0) {
+        printf("  FAIL: generate returned %d\n", ret);
+        return ret;
+    }
+
+    /* The output should contain properly escaped keyid */
+    if (strstr(generated, "key\\\"with\\\\quotes") == NULL) {
+        printf("  FAIL: escaping not found in: %s\n", generated);
+        return -1;
+    }
+
+    /* Parse it back and verify the value is unescaped */
+    ret = wc_SfParseSigInput(generated, "sig1", &parsed);
+    if (ret != 0) {
+        printf("  FAIL: re-parse returned %d\n", ret);
+        return ret;
+    }
+
+    {
+        int i;
+        for (i = 0; i < parsed.paramCount; i++) {
+            if (strcmp(parsed.params[i].name, "keyid") == 0) {
+                if (strcmp(parsed.params[i].strVal,
+                           "key\"with\\quotes") != 0) {
+                    printf("  FAIL: round-trip mismatch: '%s'\n",
+                           parsed.params[i].strVal);
+                    return -1;
+                }
+                break;
+            }
+        }
+        if (i == parsed.paramCount) {
+            printf("  FAIL: keyid param not found after parse\n");
+            return -1;
+        }
+    }
+
+    printf("  PASS\n");
+    return 0;
+}
+
+/* --- Test 15: Verify rejects NULL query when @query is signed --- */
+
+static int test_query_null_mismatch(void)
+{
+    int ret;
+    ed25519_key key, verifyKey;
+    WC_RNG rng;
+    char sigBuf[512];
+    word32 sigBufSz = sizeof(sigBuf);
+    char inputBuf[1024];
+    word32 inputBufSz = sizeof(inputBuf);
+
+    wc_HttpHeader headers[1];
+    headers[0].name  = "date";
+    headers[0].value = "Thu, 19 Mar 2026 12:00:00 GMT";
+
+    printf("Test 15: Verify rejects NULL query when @query is signed\n");
+
+    ret = wc_InitRng(&rng);
+    if (ret != 0) return ret;
+    ret = wc_ed25519_init(&key);
+    if (ret != 0) { wc_FreeRng(&rng); return ret; }
+    ret = wc_ed25519_init(&verifyKey);
+    if (ret != 0) { wc_ed25519_free(&key); wc_FreeRng(&rng); return ret; }
+
+    ret = wc_ed25519_make_key(&rng, ED25519_KEY_SIZE, &key);
+    if (ret != 0) goto cleanup15;
+
+    /* Sign with a query */
+    ret = wc_HttpSig_Sign(
+        "GET", "example.com", "/search", "?q=test",
+        headers, 1, &key, "qtest", 0,
+        sigBuf, &sigBufSz, inputBuf, &inputBufSz);
+    if (ret != 0) { printf("  FAIL: sign returned %d\n", ret); goto cleanup15; }
+
+    {
+        byte pubBuf[ED25519_PUB_KEY_SIZE];
+        word32 pubSz = sizeof(pubBuf);
+        ret = wc_ed25519_export_public(&key, pubBuf, &pubSz);
+        if (ret != 0) goto cleanup15;
+        ret = wc_ed25519_import_public(pubBuf, pubSz, &verifyKey);
+        if (ret != 0) goto cleanup15;
+    }
+
+    /* Verify with query=NULL should fail (component unresolvable) */
+    ret = wc_HttpSig_Verify(
+        "GET", "example.com", "/search", NULL,
+        headers, 1, sigBuf, inputBuf,
+        NULL, &verifyKey, 0);
+    if (ret == 0) {
+        printf("  FAIL: NULL query accepted when @query was signed\n");
+        ret = -1;
+        goto cleanup15;
+    }
+
+    ret = 0;
+    printf("  PASS\n");
+
+cleanup15:
+    wc_ed25519_free(&key);
+    wc_ed25519_free(&verifyKey);
+    wc_FreeRng(&rng);
+    return ret;
+}
+
+/* --- Test 16: Future timestamp rejection --- */
+
+static int test_future_timestamp_rejected(void)
+{
+    int ret;
+    wc_HttpHeader headers[1];
+    headers[0].name  = "date";
+    headers[0].value = "Thu, 19 Mar 2026 12:00:00 GMT";
+
+    printf("Test 16: Future timestamp rejection\n");
+
+    /* Sign with a timestamp far in the future (now + 10000s).
+     * Verify with maxAgeSec=300 — should reject because created > now. */
+    {
+        long futureTs = (long)XTIME(NULL) + 10000;
+        ret = sign_verify_roundtrip_ex(
+            "GET", "example.com", "/future-test", NULL,
+            headers, 1, NULL, 0, "future-key", futureTs, 300);
+        if (ret == 0) {
+            printf("  FAIL: future timestamp was accepted\n");
+            return -1;
+        }
+    }
+
+    /* Sign with a timestamp slightly in the future (now + 5s).
+     * Verify with maxAgeSec=0 (skip) — should succeed. */
+    {
+        long slightFuture = (long)XTIME(NULL) + 5;
+        ret = sign_verify_roundtrip_ex(
+            "GET", "example.com", "/future-test", NULL,
+            headers, 1, NULL, 0, "future-key", slightFuture, 0);
+        if (ret != 0) {
+            printf("  FAIL: maxAgeSec=0 should skip check, got %d\n", ret);
+            return ret;
+        }
+    }
+
+    printf("  PASS\n");
+    return 0;
+}
+
+/* --- Test 17: Unknown derived component rejected on verify --- */
+
+static int test_unknown_derived_component(void)
+{
+    int ret;
+    ed25519_key key, verifyKey;
+    WC_RNG rng;
+    char sigBuf[512];
+    word32 sigBufSz = sizeof(sigBuf);
+    char inputBuf[1024];
+    word32 inputBufSz = sizeof(inputBuf);
+    wc_SfSigInput sfIn;
+    char fakeInput[512];
+    word32 fakeInputSz;
+
+    wc_HttpHeader headers[1];
+    headers[0].name  = "date";
+    headers[0].value = "Thu, 19 Mar 2026 12:00:00 GMT";
+
+    printf("Test 17: Unknown derived component rejected on verify\n");
+
+    ret = wc_InitRng(&rng);
+    if (ret != 0) return ret;
+    ret = wc_ed25519_init(&key);
+    if (ret != 0) { wc_FreeRng(&rng); return ret; }
+    ret = wc_ed25519_init(&verifyKey);
+    if (ret != 0) { wc_ed25519_free(&key); wc_FreeRng(&rng); return ret; }
+
+    ret = wc_ed25519_make_key(&rng, ED25519_KEY_SIZE, &key);
+    if (ret != 0) goto cleanup17;
+
+    ret = wc_HttpSig_Sign(
+        "GET", "example.com", "/test", NULL,
+        headers, 1, &key, "deriv-test", 1700000000,
+        sigBuf, &sigBufSz, inputBuf, &inputBufSz);
+    if (ret != 0) { printf("  FAIL: sign returned %d\n", ret); goto cleanup17; }
+
+    {
+        byte pubBuf[ED25519_PUB_KEY_SIZE];
+        word32 pubSz = sizeof(pubBuf);
+        ret = wc_ed25519_export_public(&key, pubBuf, &pubSz);
+        if (ret != 0) goto cleanup17;
+        ret = wc_ed25519_import_public(pubBuf, pubSz, &verifyKey);
+        if (ret != 0) goto cleanup17;
+    }
+
+    /* Craft Signature-Input with unknown derived component @target-uri */
+    memset(&sfIn, 0, sizeof(sfIn));
+    strncpy(sfIn.label, "sig1", WC_SF_MAX_LABEL - 1);
+    strncpy(sfIn.items[0], "@target-uri", WC_SF_MAX_STRING - 1);
+    strncpy(sfIn.items[1], "@method", WC_SF_MAX_STRING - 1);
+    sfIn.itemCount = 2;
+
+    strncpy(sfIn.params[0].name, "created", WC_SF_MAX_LABEL - 1);
+    sfIn.params[0].type = WC_SF_PARAM_INTEGER;
+    sfIn.params[0].intVal = 1700000000;
+    strncpy(sfIn.params[1].name, "keyid", WC_SF_MAX_LABEL - 1);
+    sfIn.params[1].type = WC_SF_PARAM_STRING;
+    strncpy(sfIn.params[1].strVal, "deriv-test", WC_SF_MAX_STRING - 1);
+    strncpy(sfIn.params[2].name, "alg", WC_SF_MAX_LABEL - 1);
+    sfIn.params[2].type = WC_SF_PARAM_STRING;
+    strncpy(sfIn.params[2].strVal, "ed25519", WC_SF_MAX_STRING - 1);
+    sfIn.paramCount = 3;
+
+    fakeInputSz = sizeof(fakeInput);
+    ret = wc_SfGenSigInput(&sfIn, fakeInput, &fakeInputSz);
+    if (ret != 0) {
+        printf("  FAIL: gen fake input: %d\n", ret);
+        goto cleanup17;
+    }
+
+    ret = wc_HttpSig_Verify(
+        "GET", "example.com", "/test", NULL,
+        headers, 1, sigBuf, fakeInput,
+        NULL, &verifyKey, 0);
+    if (ret == 0) {
+        printf("  FAIL: unknown derived component @target-uri was accepted\n");
+        ret = -1;
+        goto cleanup17;
+    }
+
+    ret = 0;
+    printf("  PASS\n");
+
+cleanup17:
+    wc_ed25519_free(&key);
+    wc_ed25519_free(&verifyKey);
+    wc_FreeRng(&rng);
+    return ret;
+}
+
+/* --- Main --- */
+
+#define NUM_TESTS 17
+
+int main(void)
+{
+    int ret;
+    int failures = 0;
+
+    printf("=== RFC 9421 HTTP Message Signatures - Test Vectors ===\n\n");
+
+    ret = test_sf_roundtrip();              if (ret != 0) failures++;
+    ret = test_signature_base();            if (ret != 0) failures++;
+    ret = test_rfc_vector_verify();         if (ret != 0) failures++;
+    ret = test_api_roundtrip();             if (ret != 0) failures++;
+    ret = test_get_keyid();                 if (ret != 0) failures++;
+    ret = test_query_component();           if (ret != 0) failures++;
+    ret = test_header_normalization();      if (ret != 0) failures++;
+    ret = test_alg_enforcement();           if (ret != 0) failures++;
+    ret = test_timestamp_validation();      if (ret != 0) failures++;
+    ret = test_auto_timestamp();            if (ret != 0) failures++;
+    ret = test_arg_validation();            if (ret != 0) failures++;
+    ret = test_sf_integer_overflow();       if (ret != 0) failures++;
+    ret = test_adversarial_sig_input();     if (ret != 0) failures++;
+    ret = test_sf_string_escaping();        if (ret != 0) failures++;
+    ret = test_query_null_mismatch();       if (ret != 0) failures++;
+    ret = test_future_timestamp_rejected(); if (ret != 0) failures++;
+    ret = test_unknown_derived_component(); if (ret != 0) failures++;
+
+    printf("\n=== Results: %d/%d tests passed ===\n",
+           NUM_TESTS - failures, NUM_TESTS);
+
+    return failures > 0 ? 1 : 0;
+}
+
+#else
+
+int main(void)
+{
+    printf("This test requires wolfSSL compiled with:\n");
+    printf("  --enable-ed25519\n");
+    return 1;
+}
+
+#endif


### PR DESCRIPTION
Initial implementation of RFC 9421 HTTP Message Signatures as a wolfssl-examples project. Covers a minimal interoperable subset: derived components (@method, @authority, @path, @query), arbitrary HTTP header fields, Ed25519 signing/verification, single signature (sig1), and timestamp-based replay protection.

Files:
- common/wc_sf.{c,h}: Minimal RFC 8941 structured fields subset (dictionary lookup, inner lists, parameters, byte sequences)
- common/wc_http_sig.{c,h}: RFC 9421 Sign/Verify/GetKeyId API
- sign_request.c: Standalone signing example
- http_server_verify.c: Demo HTTP server with signature verification
- http_client_signed.c: Demo HTTP client sending signed requests
- test_vectors.c: 11 tests including RFC 9421 Appendix B.2.6

Design decisions:
- Ed25519-only (alg enforced on verify path)
- sigOut/inputOut are char* (NUL-terminated strings)
- Header names lowercased per RFC 9421 Section 2.1
- Portable case-insensitive comparison (no POSIX strcasecmp)
- SO_RCVTIMEO on server to prevent blocking on slow clients
- Signature base written directly to caller buffer (no double-buffer)

Known limitations:
- 32-bit long: parse_sf_integer caps at 9 digits, breaking current UNIX timestamps (needs fix, see below)
- No content-digest, multi-signature, or full RFC 8941 support
- Duplicate headers: first match wins, no folding