### PR TITLE
F-1289 F-1718 F-1707 F-1705 oob write and null pointer fixes

### DIFF
--- a/dtls/client-dtls-cid.c
+++ b/dtls/client-dtls-cid.c
@@ -140,6 +140,7 @@ int main (int argc, char** argv)
             if (readErr != SSL_ERROR_WANT_READ) {
                 printf("wolfSSL_read failed");
             }
+            continue;
         }
 
         /* Add a terminating character to the generic server message */

--- a/dtls/client-dtls-ipv6.c
+++ b/dtls/client-dtls-ipv6.c
@@ -128,6 +128,7 @@ int main (int argc, char** argv)
             if (readErr != SSL_ERROR_WANT_READ) {
                 printf("wolfSSL_read failed");
             }
+            continue;
         }
 
         /* Add a terminating character to the generic server message */

--- a/dtls/client-dtls.c
+++ b/dtls/client-dtls.c
@@ -129,10 +129,11 @@ int main (int argc, char** argv)
                 printf("wolfSSL_read failed");
             }
         }
-
-        /* Add a terminating character to the generic server message */
-        recvLine[n] = '\0';
-        fputs(recvLine, stdout);
+        else {
+            /* Add a terminating character to the generic server message */
+            recvLine[n] = '\0';
+            fputs(recvLine, stdout);
+        }
     }
 /*                End code for sending datagram to server                    */
 /*****************************************************************************/

--- a/dtls/client-dtls13-cid.c
+++ b/dtls/client-dtls13-cid.c
@@ -140,6 +140,7 @@ int main (int argc, char** argv)
             if (readErr != SSL_ERROR_WANT_READ) {
                 printf("wolfSSL_read failed");
             }
+            continue;
         }
 
         /* Add a terminating character to the generic server message */

--- a/dtls/memory-bio-dtls.c
+++ b/dtls/memory-bio-dtls.c
@@ -92,7 +92,7 @@ static void* client_thread(void* args)
     }
 
     cli_ssl = wolfSSL_new(cli_ctx);
-    if (cli_ctx == NULL) {
+    if (cli_ssl == NULL) {
         err_sys("bad client new");
     }
 
@@ -170,7 +170,7 @@ int main()
     }
 
     srv_ssl = wolfSSL_new(srv_ctx);
-    if (srv_ctx == NULL) {
+    if (srv_ssl == NULL) {
         err_sys("bad server new");
     }
 

--- a/tls/memory-tls.c
+++ b/tls/memory-tls.c
@@ -153,7 +153,7 @@ static void* client_thread(void* args)
     wolfSSL_SetIORecv(cli_ctx, ClientRecv);
 
     WOLFSSL* cli_ssl = wolfSSL_new(cli_ctx);
-    if (cli_ctx == NULL) err_sys("bad client new");
+    if (cli_ssl == NULL) err_sys("bad client new");
 
     ret = wolfSSL_connect(cli_ssl);
     if (ret != WOLFSSL_SUCCESS) err_sys("bad client tls connect");
@@ -185,7 +185,7 @@ int main()
     wolfSSL_SetIORecv(srv_ctx, ServerRecv);
 
     WOLFSSL* srv_ssl = wolfSSL_new(srv_ctx);
-    if (srv_ctx == NULL) err_sys("bad server new");
+    if (srv_ssl == NULL) err_sys("bad server new");
 
     /* start client thread */
     pthread_t tid;


### PR DESCRIPTION
- F-1718 and F-1701: Out-of-bounds array write with negative index from failed wolfSSL_read
- F-1289: Wrong variable checked after wolfSSL_new()