### PR TITLE
Return WANT_WRITE on EWOULDBLOCK in my_IOSend

### DIFF
--- a/dtls/server-dtls-callback.c
+++ b/dtls/server-dtls-callback.c
@@ -168,7 +168,7 @@ int my_IOSend(WOLFSSL* ssl, char* buff, int sz, void* ctx)
         #endif
         case EWOULDBLOCK:
             fprintf(stderr, "would block\n");
-            return WOLFSSL_CBIO_ERR_WANT_READ;
+            return WOLFSSL_CBIO_ERR_WANT_WRITE;
         case ECONNRESET:
             fprintf(stderr, "connection reset\n");
             return WOLFSSL_CBIO_ERR_CONN_RST;


### PR DESCRIPTION
wolfSSL's own send callback returns WANT_WRITE when a send would block; this one returned WANT_READ. It currently works because both are -2, but the send path should use WANT_WRITE.