### PR TITLE
Fenrir: socket fixes, wolfssl macro updates, rsa verify fix and cleanup

### DIFF
--- a/ESP32/DTLS13-wifi-station-client/main/client-dtls13.c
+++ b/ESP32/DTLS13-wifi-station-client/main/client-dtls13.c
@@ -156,7 +156,7 @@ WOLFSSL_ESP_TASK dtls13_smp_client_task(void *pvParameters)
     ESP_LOGI(TAG, "See ./include/client-dtls13.h to update settings.");
     ESP_LOGI(TAG, "Setting server address to %s, port %d.",
                    TLS_SMP_SERVER_ADDRESS, SERV_PORT);
-    memset(&servAddr, 0, sizeof(servAddr));
+    XMEMSET(&servAddr, 0, sizeof(servAddr));
     servAddr.sin_family = AF_INET;
     servAddr.sin_port = htons(SERV_PORT);
     if (inet_pton(AF_INET, TLS_SMP_SERVER_ADDRESS, &servAddr.sin_addr) < 1) {
@@ -199,10 +199,11 @@ WOLFSSL_ESP_TASK dtls13_smp_client_task(void *pvParameters)
 
         ESP_LOGI(TAG, "Sending message");
 
-        strcpy(sendLine, "Hello World.");
+        XSTRCPY(sendLine, "Hello World.");
 
         /* Send sendLine to the server */
-        if (wolfSSL_write(ssl, sendLine, strlen(sendLine)) != strlen(sendLine)) {
+        if (wolfSSL_write(ssl, sendLine, XSTRLEN(sendLine)) !=
+                XSTRLEN(sendLine)) {
             err = wolfSSL_get_error(ssl, 0);
             ESP_LOGE(TAG, "err = %d, %s\n",
                            err, wolfSSL_ERR_reason_error_string(err));

--- a/ESP32/DTLS13-wifi-station-server/main/server-dtls13.c
+++ b/ESP32/DTLS13-wifi-station-server/main/server-dtls13.c
@@ -244,7 +244,7 @@ WOLFSSL_ESP_TASK dtls13_smp_server_task(void *pvParameters)
 
     /* initialize network vars */
     if (ret == WOLFSSL_SUCCESS) {
-        memset((char *)&servAddr, 0, sizeof(servAddr));
+        XMEMSET((char *)&servAddr, 0, sizeof(servAddr));
         /* host-to-network-long conversion (htonl) */
         /* host-to-network-short conversion (htons) */
         servAddr.sin_family      = AF_INET;

--- a/ESP32/TLS13-ENC28J60-client/main/enc28j60_example_main.c
+++ b/ESP32/TLS13-ENC28J60-client/main/enc28j60_example_main.c
@@ -125,6 +125,13 @@ TickType_t DelayTicks = 5000 / portTICK_PERIOD_MS;
  **/
   
 
+static void LogSocketError(const char* fmt, int err)
+{
+    char err_msg[128];
+    XSNPRINTF(err_msg, sizeof(err_msg), fmt, err);
+    WOLFSSL_ERROR_MSG(err_msg);
+}
+
 int tls_smp_client_task() {
     int ret = WOLFSSL_SUCCESS; /* assume success until proven wrong */
     int sockfd = 0; /* the socket that will carry our secure connection */
@@ -165,7 +172,7 @@ int tls_smp_client_task() {
 #endif /* WOLFSSL_TLS13 */
    
     /* Initialize the server address struct with zeros */
-    memset(&servAddr, 0, sizeof(servAddr));
+    XMEMSET(&servAddr, 0, sizeof(servAddr));
 
     /* Fill in the server address */
     servAddr.sin_family = AF_INET; /* using IPv4      */
@@ -220,13 +227,12 @@ int tls_smp_client_task() {
          * a non-negative integer, the socket file descriptor.
         */
         sockfd = socket(AF_INET, SOCK_STREAM, 0);
-        if (sockfd > 0) {
+        if (sockfd >= 0) {
             WOLFSSL_MSG("socket creation successful\n");
         }
         else {
-            // TODO show errno 
+            LogSocketError("ERROR: failed to create a socket (errno = %d).\n", errno);
             ret = WOLFSSL_FAILURE;
-            WOLFSSL_ERROR_MSG("ERROR: failed to create a socket.\n");
         }
     }
     else {
@@ -258,8 +264,7 @@ int tls_smp_client_task() {
             WOLFSSL_MSG("sockfd connect successful\n");
         }
         else {
-            // TODO show errno
-            WOLFSSL_ERROR_MSG("ERROR: socket connect failed\n");
+            LogSocketError("ERROR: socket connect failed (errno = %d)\n", errno);
             ret = WOLFSSL_FAILURE;
         }
     }
@@ -697,13 +702,13 @@ int tls_smp_client_task() {
     */
     if (ret == WOLFSSL_SUCCESS) {
 
-        memset(buff, 0, BUFF_SIZE);
+        XMEMSET(buff, 0, BUFF_SIZE);
     
         /* get the length of our message, never longer than the declared size */
         
         /* TODO check for zero length */
         
-        len = strnlen(sendMessage, sendMessageSize);
+        len = XSTRLEN(sendMessage);
         
         /* write the message over secure connection to the server */
         if (wolfSSL_write(ssl, sendMessage, len) == len) {
@@ -783,7 +788,7 @@ int tls_smp_client_task() {
     if (ret == WOLFSSL_SUCCESS) {
         /* even though the result should be a zero-terminated string, 
          * we'll clear the receive buffer */
-        memset(buff, 0, BUFF_SIZE);
+        XMEMSET(buff, 0, BUFF_SIZE);
         
         /* read the response data from our secure connection */
         if (wolfSSL_read(ssl, buff, BUFF_SIZE - 1) > 0) {
@@ -946,7 +951,7 @@ int set_time() {
     int i = 0;
     for (i = 0; i < NTP_SERVER_COUNT; i++) {
         const char* thisServer = ntpServerList[i];
-        if (strncmp(thisServer, "\x00", 1)) {
+        if (XSTRNCMP(thisServer, "\x00", 1)) {
             /* just in case we run out of NTP servers */
             break;
         }

--- a/ESP32/TLS13-ENC28J60-server/main/enc28j60_example_main.c
+++ b/ESP32/TLS13-ENC28J60-server/main/enc28j60_example_main.c
@@ -154,6 +154,13 @@ static void sig_handler(const int sig) {
 }
 #endif
 
+static void LogSocketError(const char* fmt, int err)
+{
+    char err_msg[128];
+    XSNPRINTF(err_msg, sizeof(err_msg), fmt, err);
+    WOLFSSL_ERROR_MSG(err_msg);
+}
+
 int tls_smp_server_task() {
     int ret = WOLFSSL_SUCCESS; /* assume success until proven wrong */
     int sockfd = 0; /* the socket that will carry our secure connection */
@@ -190,7 +197,7 @@ int tls_smp_server_task() {
 #endif /* WOLFSSL_TLS13 */
     
     /* Initialize the server address struct with zeros */
-    memset(&servAddr, 0, sizeof(servAddr));
+    XMEMSET(&servAddr, 0, sizeof(servAddr));
 
     /* Fill in the server address */
     servAddr.sin_family      = AF_INET; /* using IPv4      */
@@ -280,13 +287,12 @@ int tls_smp_server_task() {
          * a non-negative integer, the socket file descriptor.
         */
         sockfd = socket(AF_INET, SOCK_STREAM, 0);
-        if (sockfd > 0) {
+        if (sockfd >= 0) {
             WOLFSSL_MSG("socket creation successful\n");
         }
         else {
-            // TODO show errno 
+            LogSocketError("ERROR: failed to create a socket (errno = %d).\n", errno);
             ret = WOLFSSL_FAILURE;
-            WOLFSSL_ERROR_MSG("ERROR: failed to create a socket.\n");
         }
     }
     else {
@@ -348,9 +354,8 @@ int tls_smp_server_task() {
             WOLFSSL_MSG("setsockopt re-use addr successful\n");
         }
         else {
-            // TODO show errno 
+            LogSocketError("ERROR: failed to setsockopt addr on socket (errno = %d).\n", errno);
             ret = WOLFSSL_FAILURE;
-            WOLFSSL_ERROR_MSG("ERROR: failed to setsockopt addr on socket.\n");
         }
     }
     else {
@@ -370,10 +375,7 @@ int tls_smp_server_task() {
             WOLFSSL_MSG("setsockopt re-use port successful\n");
         }
         else {
-            // TODO show errno 
-            // ret = WOLFSSL_FAILURE;
-            // TODO what's up with the error?
-            WOLFSSL_ERROR_MSG("ERROR: failed to setsockopt port on socket.  >> IGNORED << \n");
+            LogSocketError("ERROR: failed to setsockopt port on socket (errno = %d).  >> IGNORED << \n", errno);
         }
     } 
     else {
@@ -427,8 +429,8 @@ int tls_smp_server_task() {
             WOLFSSL_MSG("socket bind successful\n");
         }
         else {
+            LogSocketError("ERROR: failed to bind to socket (errno = %d).\n", errno);
             ret = WOLFSSL_FAILURE;
-            WOLFSSL_ERROR_MSG("ERROR: failed to bind to socket.\n");
         }
     }
 
@@ -474,10 +476,10 @@ int tls_smp_server_task() {
             WOLFSSL_MSG("socket listen successful\n");
         }
         else {
+            LogSocketError("ERROR: failed to listen to socket (errno = %d).\n", errno);
             ret = WOLFSSL_FAILURE;
-            WOLFSSL_ERROR_MSG("ERROR: failed to listen to socket.\n");
         }
-    }    
+    }
     
     /* 
     ***************************************************************************
@@ -738,21 +740,19 @@ int tls_smp_server_task() {
         /* Accept client connections */
         if ((mConnd = accept(sockfd, (struct sockaddr*)&clientAddr, &size))
             == -1) {
-            // fprintf(stderr, "ERROR: failed to accept the connection\n\n");
-            ret = -1; 
-            // TODO    goto exit;
-                WOLFSSL_ERROR_MSG("ERROR: failed socket accept\n");
-                ret = WOLFSSL_FAILURE;
+            WOLFSSL_ERROR_MSG("ERROR: failed socket accept\n");
+            ret = WOLFSSL_FAILURE;
+            break;
         }
 
         /* Create a WOLFSSL object */
         if ((ssl = wolfSSL_new(ctx)) == NULL) {
-            // fprintf(stderr, "ERROR: failed to create WOLFSSL object\n");
-            ret = -1; 
-            //TODO goto exit;
-            WOLFSSL_ERROR_MSG("ERROR: filed wolfSSL_new during loop\n");
+            WOLFSSL_ERROR_MSG("ERROR: failed wolfSSL_new during loop\n");
             ret = WOLFSSL_FAILURE;
-    }
+            close(mConnd);
+            mConnd = SOCKET_INVALID;
+            break;
+        }
 
         /* Attach wolfSSL to the socket */
         wolfSSL_set_fd(ssl, mConnd);
@@ -771,45 +771,42 @@ int tls_smp_server_task() {
         if ((ret = wolfSSL_accept(ssl)) != WOLFSSL_SUCCESS) {
             WOLFSSL_ERROR_MSG("ERROR: wolfSSL_accept\n");
             ret = WOLFSSL_FAILURE;
-            // fprintf(stderr,
-            //       "wolfSSL_accept error = %d\n",
-            //    wolfSSL_get_error(ssl, ret));
-            // TODO goto exit;
         }
         else {
             WOLFSSL_MSG("Client connected successfully\n");
         }
 
-
 #ifdef HAVE_SECRET_CALLBACK
-        wolfSSL_FreeArrays(ssl);
+        if (ret == WOLFSSL_SUCCESS) {
+            wolfSSL_FreeArrays(ssl);
+        }
 #endif
 
         /* Read the client data into our buff array */
-        memset(buff, 0, sizeof(buff));
-        if ((ret = wolfSSL_read(ssl, buff, sizeof(buff) - 1)) < 0) {
-            // fprintf(stderr, "ERROR: failed to read\n");
-            //TODO goto exit;
+        if (ret == WOLFSSL_SUCCESS) {
+            XMEMSET(buff, 0, sizeof(buff));
+            if (wolfSSL_read(ssl, buff, sizeof(buff) - 1) <= 0) {
+                WOLFSSL_ERROR_MSG("ERROR: failed to read\n");
+                ret = WOLFSSL_FAILURE;
+            }
         }
 
-        /* Print to stdout any data the client sends */
-        // printf("Client: %s\n", buff);
+        if (ret == WOLFSSL_SUCCESS) {
+            /* Check for server shutdown command */
+            if (XSTRNCMP(buff, "shutdown", 8) == 0) {
+                mShutdown = 1;
+            }
 
-        /* Check for server shutdown command */
-        if (strncmp(buff, "shutdown", 8) == 0) {
-            // printf("Shutdown command issued!\n");
-            mShutdown = 1;
-        }
+            /* Write our reply into buff */
+            XMEMSET(buff, 0, sizeof(buff));
+            XMEMCPY(buff, reply, XSTRLEN(reply));
+            len = XSTRLEN(buff);
 
-        /* Write our reply into buff */
-        memset(buff, 0, sizeof(buff));
-        memcpy(buff, reply, strlen(reply));
-        len = strnlen(buff, sizeof(buff));
-
-        /* Reply back to the client */
-        if ((ret = wolfSSL_write(ssl, buff, len)) != len) {
-            // fprintf(stderr, "ERROR: failed to write\n");
-            // TODO goto exit;
+            /* Reply back to the client */
+            if (wolfSSL_write(ssl, buff, len) != len) {
+                WOLFSSL_ERROR_MSG("ERROR: failed to write\n");
+                ret = WOLFSSL_FAILURE;
+            }
         }
 
         /* Cleanup after this connection */
@@ -822,6 +819,12 @@ int tls_smp_server_task() {
             close(mConnd); /* Close the connection to the client   */
             mConnd = SOCKET_INVALID;
         }
+
+        /* A handshake (wolfSSL_accept) or read/write failure on this client's
+         * connection shouldn't stop the server from accepting the next one.
+         * Fatal setup failures above (socket accept/wolfSSL_new) already break
+         * out of the loop. */
+        ret = WOLFSSL_SUCCESS;
     }
 
     WOLFSSL_MSG("Shutdown complete\n");
@@ -967,7 +970,7 @@ int set_time() {
     int i = 0;
     for (i = 0; i < NTP_SERVER_COUNT; i++) {
         const char* thisServer = ntpServerList[i];
-        if (strncmp(thisServer, "\x00", 1)) {
+        if (XSTRNCMP(thisServer, "\x00", 1)) {
             /* just in case we run out of NTP servers */
             break;
         }

--- a/ESP32/TLS13-wifi_station-client/main/station_example_main.c
+++ b/ESP32/TLS13-wifi_station-client/main/station_example_main.c
@@ -9,6 +9,7 @@
 
 
 #include <string.h>
+#include <errno.h>
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
 #include "freertos/event_groups.h"
@@ -192,7 +193,7 @@ int set_time() {
     int i = 0;
     for (i = 0; i < NTP_SERVER_COUNT; i++) {
         const char* thisServer = ntpServerList[i];
-        if (strncmp(thisServer, "\x00", 1)) {
+        if (XSTRNCMP(thisServer, "\x00", 1)) {
             /* just in case we run out of NTP servers */
             break;
         }
@@ -302,7 +303,7 @@ int tls_smp_client_task() {
 
 
     /* Initialize the server address struct with zeros */
-    memset(&servAddr, 0, sizeof(servAddr));
+    XMEMSET(&servAddr, 0, sizeof(servAddr));
 
     /* Fill in the server address */
     servAddr.sin_family = AF_INET; /* using IPv4      */
@@ -357,13 +358,13 @@ int tls_smp_client_task() {
          * a non-negative integer, the socket file descriptor.
         */
         sockfd = socket(AF_INET, SOCK_STREAM, 0);
-        if (sockfd > 0) {
+        if (sockfd >= 0) {
             ESP_LOGI(TAG,"socket creation successful\n");
         }
         else {
-            // TODO show errno
+            ESP_LOGE(TAG,
+                     "ERROR: failed to create a socket (errno = %d).\n", errno);
             ret = WOLFSSL_FAILURE;
-            ESP_LOGE(TAG, "ERROR: failed to create a socket.\n");
         }
     }
     else {
@@ -398,8 +399,8 @@ int tls_smp_client_task() {
             ESP_LOGI(TAG,"sockfd connect successful\n");
         }
         else {
-            // TODO show errno
-            ESP_LOGE(TAG, "ERROR: socket connect failed\n");
+            ESP_LOGE(TAG,
+                     "ERROR: socket connect failed (errno = %d)\n", errno);
             ret = WOLFSSL_FAILURE;
         }
     }
@@ -837,13 +838,13 @@ int tls_smp_client_task() {
     */
     if (ret == WOLFSSL_SUCCESS) {
 
-        memset(buff, 0, BUFF_SIZE);
+        XMEMSET(buff, 0, BUFF_SIZE);
 
         /* get the length of our message, never longer than the declared size */
 
         /* TODO check for zero length */
 
-        len = strnlen(sendMessage, sendMessageSize);
+        len = XSTRLEN(sendMessage);
 
         /* write the message over secure connection to the server */
         if (wolfSSL_write(ssl, sendMessage, len) == len) {
@@ -923,7 +924,7 @@ int tls_smp_client_task() {
     if (ret == WOLFSSL_SUCCESS) {
         /* even though the result should be a zero-terminated string,
          * we'll clear the receive buffer */
-        memset(buff, 0, BUFF_SIZE);
+        XMEMSET(buff, 0, BUFF_SIZE);
 
         /* read the response data from our secure connection */
         if (wolfSSL_read(ssl, buff, BUFF_SIZE - 1) > 0) {

--- a/ESP32/TLS13-wifi_station-server/main/station_example_main.c
+++ b/ESP32/TLS13-wifi_station-server/main/station_example_main.c
@@ -9,6 +9,7 @@
 
 
 #include <string.h>
+#include <errno.h>
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
 #include "freertos/event_groups.h"
@@ -196,7 +197,7 @@ int set_time() {
     int i = 0;
     for (i = 0; i < NTP_SERVER_COUNT; i++) {
         const char* thisServer = ntpServerList[i];
-        if (strncmp(thisServer, "\x00", 1)) {
+        if (XSTRNCMP(thisServer, "\x00", 1)) {
             /* just in case we run out of NTP servers */
             break;
         }
@@ -291,6 +292,13 @@ void wifi_init_sta(void)
     vEventGroupDelete(s_wifi_event_group);
 }
 
+static void LogSocketError(const char* fmt, int err)
+{
+    char err_msg[128];
+    XSNPRINTF(err_msg, sizeof(err_msg), fmt, err);
+    WOLFSSL_ERROR_MSG(err_msg);
+}
+
 int tls_smp_server_task() {
     int ret = WOLFSSL_SUCCESS; /* assume success until proven wrong */
     int sockfd = 0; /* the socket that will carry our secure connection */
@@ -330,7 +338,7 @@ int tls_smp_server_task() {
 #endif /* WOLFSSL_TLS13 */
 
     /* Initialize the server address struct with zeros */
-    memset(&servAddr, 0, sizeof(servAddr));
+    XMEMSET(&servAddr, 0, sizeof(servAddr));
 
     /* Fill in the server address */
     servAddr.sin_family      = AF_INET; /* using IPv4      */
@@ -427,13 +435,12 @@ int tls_smp_server_task() {
          * a non-negative integer, the socket file descriptor.
         */
         sockfd = socket(AF_INET, SOCK_STREAM, 0);
-        if (sockfd > 0) {
+        if (sockfd >= 0) {
             WOLFSSL_MSG("socket creation successful\n");
         }
         else {
-            // TODO show errno
+            LogSocketError("ERROR: failed to create a socket (errno = %d).\n", errno);
             ret = WOLFSSL_FAILURE;
-            WOLFSSL_ERROR_MSG("ERROR: failed to create a socket.\n");
         }
     }
     else {
@@ -501,9 +508,8 @@ int tls_smp_server_task() {
             WOLFSSL_MSG("setsockopt re-use addr successful\n");
         }
         else {
-            ESP_LOGE(TAG, "setsockopt failed with code %i", soc_ret);
+            LogSocketError("ERROR: failed to setsockopt addr on socket (errno = %d).\n", errno);
             ret = WOLFSSL_FAILURE;
-            WOLFSSL_ERROR_MSG("ERROR: failed to setsockopt addr on socket.\n");
         }
     }
     else {
@@ -584,8 +590,8 @@ int tls_smp_server_task() {
             WOLFSSL_MSG("socket bind successful\n");
         }
         else {
+            LogSocketError("ERROR: failed to bind to socket (errno = %d).\n", errno);
             ret = WOLFSSL_FAILURE;
-            WOLFSSL_ERROR_MSG("ERROR: failed to bind to socket.\n");
         }
     }
 
@@ -632,8 +638,8 @@ int tls_smp_server_task() {
             WOLFSSL_MSG("socket listen successful\n");
         }
         else {
+            LogSocketError("ERROR: failed to listen to socket (errno = %d).\n", errno);
             ret = WOLFSSL_FAILURE;
-            WOLFSSL_ERROR_MSG("ERROR: failed to listen to socket.\n");
         }
     }
 
@@ -913,20 +919,18 @@ int tls_smp_server_task() {
         /* Accept client connections */
         if ((mConnd = accept(sockfd, (struct sockaddr*)&clientAddr, &size))
             == -1) {
-
-            ret = -1;
-            goto exit;
             WOLFSSL_ERROR_MSG("ERROR: failed socket connection accept\n");
             ret = WOLFSSL_FAILURE;
+            break;
         }
 
         /* Create a WOLFSSL object */
         if ((ssl = wolfSSL_new(ctx)) == NULL) {
             WOLFSSL_ERROR_MSG("ERROR: failed to create WOLFSSL object\n");
-            ret = -1;
-            goto exit;
-            WOLFSSL_ERROR_MSG("ERROR: failed wolfSSL_new during loop\n");
             ret = WOLFSSL_FAILURE;
+            close(mConnd);
+            mConnd = SOCKET_INVALID;
+            break;
         }
 
         /* Attach wolfSSL to the socket */
@@ -945,47 +949,56 @@ int tls_smp_server_task() {
         /* Establish TLS connection */
         if ((ret = wolfSSL_accept(ssl)) != WOLFSSL_SUCCESS) {
             WOLFSSL_ERROR_MSG("ERROR: wolfSSL_accept\n");
-
-            ret = WOLFSSL_FAILURE;
             ESP_LOGE(TAG, "wolfSSL_accept error = %d\n",
                            wolfSSL_get_error(ssl, ret));
-            goto exit;
+            ret = WOLFSSL_FAILURE;
         }
         else {
             WOLFSSL_MSG("Client connected successfully\n");
         }
 
 #ifdef HAVE_SECRET_CALLBACK
-        wolfSSL_FreeArrays(ssl);
+        if (ret == WOLFSSL_SUCCESS) {
+            wolfSSL_FreeArrays(ssl);
+        }
 #endif
 
         /* Read the client data into our buff array */
-        memset(buff, 0, sizeof(buff));
-        if ((ret = wolfSSL_read(ssl, buff, sizeof(buff) - 1)) < 0) {
-            ESP_LOGE(TAG, "wolfSSL_read error = %d\n",
-                           wolfSSL_get_error(ssl, ret));
-            goto exit;
+        if (ret == WOLFSSL_SUCCESS) {
+            int readRet;
+            XMEMSET(buff, 0, sizeof(buff));
+            readRet = wolfSSL_read(ssl, buff, sizeof(buff) - 1);
+            if (readRet <= 0) {
+                ESP_LOGE(TAG, "wolfSSL_read error = %d\n",
+                               wolfSSL_get_error(ssl, readRet));
+                ret = WOLFSSL_FAILURE;
+            }
         }
 
-        /* Print any data the client sends */
-        ESP_LOGI(TAG, "Client: %s\n", buff);
+        if (ret == WOLFSSL_SUCCESS) {
+            /* Print any data the client sends */
+            ESP_LOGI(TAG, "Client: %s\n", buff);
 
-        /* Check for server shutdown command */
-        if (strncmp(buff, "shutdown", 8) == 0) {
-            ESP_LOGI(TAG, "Shutdown command issued!\n");
-            mShutdown = 1;
-        }
+            /* Check for server shutdown command */
+            if (XSTRNCMP(buff, "shutdown", 8) == 0) {
+                ESP_LOGI(TAG, "Shutdown command issued!\n");
+                mShutdown = 1;
+            }
 
-        /* Write our reply into buff */
-        memset(buff, 0, sizeof(buff));
-        memcpy(buff, reply, strlen(reply));
-        len = strnlen(buff, sizeof(buff));
+            /* Write our reply into buff */
+            XMEMSET(buff, 0, sizeof(buff));
+            XMEMCPY(buff, reply, XSTRLEN(reply));
+            len = XSTRLEN(buff);
 
-        /* Reply back to the client */
-        if ((ret = wolfSSL_write(ssl, buff, len)) != len) {
-            ESP_LOGE(TAG, "wolfSSL_write error = %d\n",
-                           wolfSSL_get_error(ssl, ret));
-            goto exit;
+            /* Reply back to the client */
+            {
+                int writeRet = wolfSSL_write(ssl, buff, len);
+                if (writeRet != len) {
+                    ESP_LOGE(TAG, "wolfSSL_write error = %d\n",
+                                   wolfSSL_get_error(ssl, writeRet));
+                    ret = WOLFSSL_FAILURE;
+                }
+            }
         }
 
         /* Cleanup after this connection */
@@ -998,6 +1011,12 @@ int tls_smp_server_task() {
             close(mConnd); /* Close the connection to the client   */
             mConnd = SOCKET_INVALID;
         }
+
+        /* A handshake (wolfSSL_accept) or read/write failure on this client's
+         * connection shouldn't stop the server from accepting the next one.
+         * Fatal setup failures above (socket accept/wolfSSL_new) already break
+         * out of the loop. */
+        ret = WOLFSSL_SUCCESS;
     }
 
     WOLFSSL_MSG("Shutdown complete\n");
@@ -1009,7 +1028,6 @@ int tls_smp_server_task() {
     *
     ***************************************************************************
     */
-exit:
     if (mConnd != SOCKET_INVALID) {
         close(mConnd); /* Close the connection to the client      */
         mConnd = SOCKET_INVALID;

--- a/can-bus/common.c
+++ b/can-bus/common.c
@@ -161,7 +161,7 @@ int setup_connection(const char *interface, int local_id, int remote_id)
     /* Connect to CAN bus provided on command line, filter out everything
      * except for the remote CAN ID */
     sock = can_connect(interface, remote_id);
-    if (sock < 1) {
+    if (sock < 0) {
         return -1;
     }
     can_con_info.sock = sock;

--- a/dtls/client-dtls-export.c
+++ b/dtls/client-dtls-export.c
@@ -50,7 +50,7 @@ static void Usage(const char* progName)
 
 int main(int argc, char** argv)
 {
-    int             sockfd = 0;
+    int             sockfd = -1;
     int             ret;
     struct          sockaddr_in servAddr;
     WOLFSSL*        ssl = NULL;
@@ -203,7 +203,7 @@ cleanup:
         wolfSSL_shutdown(ssl);
         wolfSSL_free(ssl);
     }
-    if (sockfd > 0) close(sockfd);
+    if (sockfd >= 0) close(sockfd);
     if (ctx != NULL) wolfSSL_CTX_free(ctx);
     wolfSSL_Cleanup();
 

--- a/dtls/client-dtls-import.c
+++ b/dtls/client-dtls-import.c
@@ -49,7 +49,7 @@ static void Usage(const char* progName)
 
 int main(int argc, char** argv)
 {
-    int             sockfd = 0;
+    int             sockfd = -1;
     int             ret;
     struct          sockaddr_in servAddr;
     WOLFSSL*        ssl = NULL;
@@ -60,6 +60,7 @@ int main(int argc, char** argv)
     unsigned char*  sessionBuf = NULL;
     unsigned int    sessionSz = 0;
     int             n;
+    int             err_occurred = 0;
 
     /* Program argument checking */
     if (argc < 2 || argc > 3) {
@@ -149,6 +150,8 @@ int main(int argc, char** argv)
             int err = wolfSSL_get_error(ssl, ret);
             fprintf(stderr, "Error: wolfSSL_write failed: %d (%s)\n",
                     err, wolfSSL_ERR_reason_error_string(err));
+            ret = 1;
+            err_occurred = 1;
             break;
         }
         printf("Sent: %s", sendLine);
@@ -164,6 +167,8 @@ int main(int argc, char** argv)
             if (err != SSL_ERROR_WANT_READ) {
                 fprintf(stderr, "Error: wolfSSL_read failed: %d (%s)\n",
                         err, wolfSSL_ERR_reason_error_string(err));
+                ret = 1;
+                err_occurred = 1;
                 break;
             }
         }
@@ -171,7 +176,9 @@ int main(int argc, char** argv)
         printf("\nEnter message (or 'quit' to exit):\n");
     }
 
-    ret = 0;
+    if (!err_occurred) {
+        ret = 0;
+    }
 
 cleanup:
     if (sessionBuf != NULL) free(sessionBuf);
@@ -179,7 +186,7 @@ cleanup:
         wolfSSL_shutdown(ssl);
         wolfSSL_free(ssl);
     }
-    if (sockfd > 0) close(sockfd);
+    if (sockfd >= 0) close(sockfd);
     if (ctx != NULL) wolfSSL_CTX_free(ctx);
     wolfSSL_Cleanup();
 

--- a/dtls/client-dtls-resume.c
+++ b/dtls/client-dtls-resume.c
@@ -47,7 +47,7 @@ main(int    argc,
      char * argv[])
 {
     /* standard variables used in a dtls client*/
-    int               sockfd = 0;
+    int               sockfd = -1;
     int               err1;
     const char *      host = argv[1];
     WOLFSSL *         ssl = NULL; /* The ssl for original connection. */
@@ -88,7 +88,7 @@ main(int    argc,
 
     sockfd = new_udp_client_socket(ssl, host);
 
-    if (sockfd <= 0) {
+    if (sockfd < 0) {
         printf("error: new_udp_client_socket failed\n");
         return EXIT_FAILURE;
     }
@@ -123,7 +123,7 @@ main(int    argc,
     close(sockfd);
 
     ssl = NULL;
-    sockfd = 0;
+    sockfd = -1;
 
     /* Make a new WOLFSSL. */
     ssl_res = wolfSSL_new(ctx);
@@ -143,7 +143,7 @@ main(int    argc,
     /* Open a new udp socket. */
     sockfd = new_udp_client_socket(ssl_res, host);
 
-    if (sockfd <= 0) {
+    if (sockfd < 0) {
         printf("error: new_udp_client_socket failed\n");
         return EXIT_FAILURE;
     }
@@ -173,7 +173,7 @@ main(int    argc,
 
     ssl_res = NULL;
     session = NULL;
-    sockfd = 0;
+    sockfd = -1;
 
     return 0;
 }
@@ -187,12 +187,12 @@ new_udp_client_socket(WOLFSSL *    ssl,
                       const char * host)
 {
     struct sockaddr_in  servAddr;
-    int                 sockfd = 0;
+    int                 sockfd = -1;
     int                 ret = 0;
 
     sockfd = socket(AF_INET, SOCK_DGRAM, 0);
 
-    if (sockfd <= 0) {
+    if (sockfd < 0) {
         int errsave = errno;
         printf("error: socket returned %d\n", errsave);
         return -1;
@@ -208,7 +208,7 @@ new_udp_client_socket(WOLFSSL *    ssl,
     if (ret != 1) {
         printf("error: inet_pton %s returned %d\n", host, ret);
         close(sockfd);
-        sockfd = 0;
+        sockfd = -1;
         return -1;
     }
 
@@ -217,7 +217,7 @@ new_udp_client_socket(WOLFSSL *    ssl,
     if (ret != SSL_SUCCESS) {
         printf("error: wolfSSL_dtls_set_peer returned %d\n", ret);
         close(sockfd);
-        sockfd = 0;
+        sockfd = -1;
         return -1;
     }
 

--- a/dtls/client-dtls-threaded.c
+++ b/dtls/client-dtls-threaded.c
@@ -47,7 +47,7 @@ typedef struct {
     WOLFSSL_CTX * ctx;
 } thread_args_t;
 
-static void   safer_shutdown(thread_args_t * args);
+static int    safer_shutdown(thread_args_t * args);
 static void * client_work(void * arg);
 
 int
@@ -107,6 +107,7 @@ main(int    argc,
 
     for (size_t i = 0; i < n_threads; ++i) {
         args[i].ctx = ctx;
+        args[i].activefd = -1;
         ret = pthread_create(&threads[i], NULL, client_work, &args[i]);
 
         if (ret == 0 ) {
@@ -123,6 +124,14 @@ main(int    argc,
             pthread_join(threads[i], NULL);
             printf("info: joined thread: %ld\n", (long)threads[i]);
             threads[i] = 0;
+        }
+    }
+
+    /* All threads exited. Do a final cleanup pass just in case. */
+    for (size_t i = 0; i < n_threads; ++i) {
+        ret = safer_shutdown(&args[i]);
+        if (ret != 0) {
+            printf("error: safer_shutdown failed: %d\n", ret);
         }
     }
 
@@ -159,18 +168,22 @@ client_work(void * args)
     ret = inet_pton(AF_INET, localhost_ip, &servAddr.sin_addr);
     if (ret != 1) {
         printf("error: inet_pton %s returned %d\n", localhost_ip, ret);
+        safer_shutdown(thread_args);
         return NULL;
     }
 
     ret = wolfSSL_dtls_set_peer(thread_args->ssl, &servAddr, sizeof(servAddr));
     if (ret != SSL_SUCCESS) {
         printf("error: wolfSSL_dtls_set_peer returned %d\n", ret);
+        safer_shutdown(thread_args);
         return NULL;
     }
 
     thread_args->activefd = socket(AF_INET, SOCK_DGRAM, 0);
-    if (thread_args->activefd <= 0) {
+    if (thread_args->activefd < 0) {
         printf("error: socket returned %d\n", thread_args->activefd);
+        thread_args->activefd = -1;
+        safer_shutdown(thread_args);
         return NULL;
     }
 
@@ -183,6 +196,7 @@ client_work(void * args)
         printf("error: thread %ld: wolfSSL_connect returned = %d, %s\n",
                 (long)pthread_self(), err1,
                 wolfSSL_ERR_reason_error_string(err1));
+        safer_shutdown(thread_args);
         return NULL;
     }
 
@@ -246,33 +260,48 @@ client_work(void * args)
         sleep(1);
     }
 
-    safer_shutdown(thread_args);
+    ret = safer_shutdown(thread_args);
+    if (ret != 0) {
+        printf("error: safer_shutdown failed: %d\n", ret);
+    }
 
     return NULL;
 }
 
 /* Small shutdown wrapper to safely clean up a thread's
  * connection. */
-static void
+static int
 safer_shutdown(thread_args_t * args)
 {
+    int ret = 0;
+
     if (args == NULL) {
         printf("error: safer_shutdown with null args\n");
-        return;
+        return -1;
     }
 
     if (args->ssl != NULL) {
         printf("info: closed tls session: %p\n", (void*) args->ssl);
-        wolfSSL_shutdown(args->ssl);
+        ret = wolfSSL_shutdown(args->ssl);
+
+        if (ret != WOLFSSL_SUCCESS) {
+            printf("warning: wolfSSL_shutdown did not complete cleanly: %d\n",
+                    ret);
+            ret = -1;
+        }
+        else {
+            ret = 0;
+        }
+
         wolfSSL_free(args->ssl);
         args->ssl = NULL;
     }
 
-    if (args->activefd > 0) {
+    if (args->activefd >= 0) {
         printf("info: closed socket: %d\n", args->activefd);
         close(args->activefd);
-        args->activefd = 0;
+        args->activefd = -1;
     }
 
-    return;
+    return ret;
 }

--- a/dtls/client-dtls.c
+++ b/dtls/client-dtls.c
@@ -62,7 +62,7 @@ int main (int argc, char** argv)
 
     /* Initialize wolfSSL before assigning ctx */
     wolfSSL_Init();
-  
+
     /* wolfSSL_Debugging_ON(); */
 
     if ( (ctx = wolfSSL_CTX_new(wolfDTLSv1_2_client_method())) == NULL) {
@@ -72,7 +72,7 @@ int main (int argc, char** argv)
 
     /* Load certificates into ctx variable */
     if (wolfSSL_CTX_load_verify_locations(ctx, certs, 0)
-	    != SSL_SUCCESS) {
+            != SSL_SUCCESS) {
         fprintf(stderr, "Error loading %s, please check the file.\n", certs);
         return 1;
     }
@@ -103,9 +103,9 @@ int main (int argc, char** argv)
     /* Set the file descriptor for ssl and connect with ssl variable */
     wolfSSL_set_fd(ssl, sockfd);
     if (wolfSSL_connect(ssl) != SSL_SUCCESS) {
-	    err1 = wolfSSL_get_error(ssl, 0);
-	    printf("err = %d, %s\n", err1, wolfSSL_ERR_reason_error_string(err1));
-	    printf("SSL_connect failed");
+        err1 = wolfSSL_get_error(ssl, 0);
+        printf("err = %d, %s\n", err1, wolfSSL_ERR_reason_error_string(err1));
+        printf("SSL_connect failed");
         return 1;
     }
 
@@ -129,10 +129,11 @@ int main (int argc, char** argv)
                 printf("wolfSSL_read failed");
             }
         }
-
-        /* Add a terminating character to the generic server message */
-        recvLine[n] = '\0';
-        fputs(recvLine, stdout);
+        else {
+            /* Add a terminating character to the generic server message */
+            recvLine[n] = '\0';
+            fputs(recvLine, stdout);
+        }
     }
 /*                End code for sending datagram to server                    */
 /*****************************************************************************/

--- a/dtls/client-dtls13-cid.c
+++ b/dtls/client-dtls13-cid.c
@@ -140,6 +140,7 @@ int main (int argc, char** argv)
             if (readErr != SSL_ERROR_WANT_READ) {
                 printf("wolfSSL_read failed");
             }
+            continue;
         }
 
         /* Add a terminating character to the generic server message */

--- a/dtls/memory-bio-dtls.c
+++ b/dtls/memory-bio-dtls.c
@@ -92,7 +92,7 @@ static void* client_thread(void* args)
     }
 
     cli_ssl = wolfSSL_new(cli_ctx);
-    if (cli_ctx == NULL) {
+    if (cli_ssl == NULL) {
         err_sys("bad client new");
     }
 

--- a/dtls/memory-bio-dtls.c
+++ b/dtls/memory-bio-dtls.c
@@ -170,7 +170,7 @@ int main()
     }
 
     srv_ssl = wolfSSL_new(srv_ctx);
-    if (srv_ctx == NULL) {
+    if (srv_ssl == NULL) {
         err_sys("bad server new");
     }
 

--- a/dtls/server-dtls-export.c
+++ b/dtls/server-dtls-export.c
@@ -63,7 +63,7 @@ int main(int argc, char** argv)
     char            servKeyLoc[] = "../certs/server-key.pem";
     int             ret = 0;
     int             on = 1;
-    int             listenfd = 0;
+    int             listenfd = -1;
     int             recvLen;
     WOLFSSL_CTX*    ctx = NULL;
     WOLFSSL*        ssl = NULL;
@@ -274,7 +274,7 @@ cleanup:
         wolfSSL_shutdown(ssl);
         wolfSSL_free(ssl);
     }
-    if (listenfd > 0) close(listenfd);
+    if (listenfd >= 0) close(listenfd);
     if (ctx != NULL) wolfSSL_CTX_free(ctx);
     wolfSSL_Cleanup();
 

--- a/dtls/server-dtls-import.c
+++ b/dtls/server-dtls-import.c
@@ -59,7 +59,7 @@ int main(int argc, char** argv)
 {
     int             ret = 0;
     int             on = 1;
-    int             listenfd = 0;
+    int             listenfd = -1;
     int             recvLen;
     WOLFSSL_CTX*    ctx = NULL;
     WOLFSSL*        ssl = NULL;
@@ -72,6 +72,7 @@ int main(int argc, char** argv)
     const char*     sessionFile = DEFAULT_SERVER_SESSION_FILE;
     unsigned char*  sessionBuf = NULL;
     unsigned int    sessionSz = 0;
+    int             err_occurred = 0;
 
     /* Program argument checking */
     if (argc > 2) {
@@ -202,6 +203,8 @@ int main(int argc, char** argv)
                 int err = wolfSSL_get_error(ssl, ret);
                 fprintf(stderr, "Error: wolfSSL_write failed: %d (%s)\n",
                         err, wolfSSL_ERR_reason_error_string(err));
+                ret = 1;
+                err_occurred = 1;
                 break;
             }
         }
@@ -210,12 +213,16 @@ int main(int argc, char** argv)
             if (err != SSL_ERROR_WANT_READ) {
                 fprintf(stderr, "Error: wolfSSL_read failed: %d (%s)\n",
                         err, wolfSSL_ERR_reason_error_string(err));
+                ret = 1;
+                err_occurred = 1;
                 break;
             }
         }
     }
 
-    ret = 0;
+    if (!err_occurred) {
+        ret = 0;
+    }
 
 cleanup:
     if (sessionBuf != NULL) free(sessionBuf);
@@ -223,7 +230,7 @@ cleanup:
         wolfSSL_shutdown(ssl);
         wolfSSL_free(ssl);
     }
-    if (listenfd > 0) close(listenfd);
+    if (listenfd >= 0) close(listenfd);
     if (ctx != NULL) wolfSSL_CTX_free(ctx);
     wolfSSL_Cleanup();
 

--- a/dtls/server-dtls-threaded.c
+++ b/dtls/server-dtls-threaded.c
@@ -63,7 +63,7 @@ static WOLFSSL_CTX * ctx = NULL;
 static volatile int  stop_server = 0;
 
 static int    new_udp_listen_socket(void);
-static void   safer_shutdown(thread_args_t * args);
+static int    safer_shutdown(thread_args_t * args);
 static void * server_work(void * thread_args);
 static void   sig_handler(const int sig);
 static void   cleanup_threadpool(pthread_t * threads, thread_args_t * args,
@@ -78,7 +78,7 @@ main(int   argc,
     char               servKeyLoc[] =  "../certs/server-key.pem";
     int                ret = 0;
     /* Variables for awaiting datagram */
-    int                listenfd = 0;   /* Initialize our socket */
+    int                listenfd = -1;  /* Initialize our socket */
     struct sockaddr_in cliaddr;         /* the client's address */
     socklen_t          cliLen = sizeof(cliaddr);
     /* variables needed for threading */
@@ -89,6 +89,9 @@ main(int   argc,
 
     memset(threads, 0, sizeof(threads));
     memset(args, 0, sizeof(args));
+    for (size_t i = 0; i < DTLS_NUMTHREADS; ++i) {
+        args[i].activefd = -1;
+    }
 
     while ((opt = getopt(argc, argv, "t:?")) != -1) {
         switch (opt) {
@@ -159,7 +162,7 @@ main(int   argc,
     /* Create a UDP/IP socket */
     listenfd = new_udp_listen_socket();
 
-    if (listenfd <= 0 ) {
+    if (listenfd < 0) {
         printf("error: cannot create socket: %d\n", listenfd);
         return EXIT_FAILURE;
     }
@@ -243,7 +246,10 @@ main(int   argc,
 
     /* All threads exited. Do a final cleanup pass just in case. */
     for (size_t i = 0; i < n_threads; ++i) {
-        safer_shutdown(&args[i]);
+        ret = safer_shutdown(&args[i]);
+        if (ret != 0) {
+            printf("error: safer_shutdown failed: %d\n", ret);
+        }
     }
 
     wolfSSL_CTX_free(ctx);
@@ -256,13 +262,13 @@ static int
 new_udp_listen_socket(void)
 {
     struct sockaddr_in listen_addr;        /* our server's address */
-    int                sockfd = 0;
+    int                sockfd = -1;
     int                ret = 0;
     int                on = 1;
 
     sockfd = socket(AF_INET, SOCK_DGRAM, 0);
 
-    if (sockfd <= 0) {
+    if (sockfd < 0) {
         int errsave = errno;
         printf("error: socket returned %d\n", errsave);
         return -1;
@@ -277,14 +283,14 @@ new_udp_listen_socket(void)
     if (setsockopt(sockfd, SOL_SOCKET, SO_REUSEADDR, (char*)&on, sizeof(on)) != 0) {
         printf("error: setsockopt() with SO_REUSEADDR");
         close(sockfd);
-        sockfd = 0;
+        sockfd = -1;
         return -1;
     }
 #ifdef SO_REUSEPORT
     if (setsockopt(sockfd, SOL_SOCKET, SO_REUSEPORT, (char*)&on, sizeof(on)) != 0) {
         printf("error: setsockopt() with SO_REUSEPORT");
         close(sockfd);
-        sockfd = 0;
+        sockfd = -1;
         return -1;
     }
 #endif
@@ -296,7 +302,7 @@ new_udp_listen_socket(void)
         int errsave = errno;
         printf("error: bind returned %d\n", errsave);
         close(sockfd);
-        sockfd = 0;
+        sockfd = -1;
         return -1;
     }
 
@@ -370,21 +376,24 @@ server_work(void * args)
         }
     }
 
-    safer_shutdown(thread_args);
+    ret = safer_shutdown(thread_args);
+    if (ret != 0) {
+        printf("error: safer_shutdown failed: %d\n", ret);
+    }
     printf("info: exiting thread %ld\n", (long)pthread_self());
     pthread_exit(NULL);
 }
 
 /* Small shutdown wrapper to safely clean up a thread's
  * connection. */
-static void
+static int
 safer_shutdown(thread_args_t * args)
 {
-    int ret;
+    int ret = 0;
 
     if (args == NULL) {
         printf("error: safer_shutdown with null args\n");
-        return;
+        return -1;
     }
 
     if (args->ssl != NULL) {
@@ -395,19 +404,28 @@ safer_shutdown(thread_args_t * args)
         if (ret != WOLFSSL_SUCCESS)
             ret = wolfSSL_shutdown(args->ssl);
 
+        if (ret != WOLFSSL_SUCCESS) {
+            printf("warning: wolfSSL_shutdown did not complete cleanly: %d\n",
+                    ret);
+            ret = -1;
+        }
+        else {
+            ret = 0;
+        }
+
         wolfSSL_free(args->ssl);
         args->ssl = NULL;
     }
 
-    if (args->activefd > 0) {
+    if (args->activefd >= 0) {
         printf("info: closed socket: %d\n", args->activefd);
         close(args->activefd);
-        args->activefd = 0;
+        args->activefd = -1;
     }
 
     args->done = 1;
 
-    return;
+    return ret;
 }
 
 static void

--- a/dtls/server-dtls.c
+++ b/dtls/server-dtls.c
@@ -40,7 +40,6 @@
 #define SERV_PORT   11111           /* define our server port number */
 #define MSGLEN      4096
 
-static int cleanup = 0;                 /* To handle shutdown */
 static struct sockaddr_in servAddr;     /* our server's address */
 static struct sockaddr_in cliaddr;      /* the client's address */
 
@@ -59,7 +58,7 @@ int main(int argc, char** argv)
     int           res = 1;
     int           bytesReceived = 0;
     int           recvLen = 0;    /* length of message */
-    int           listenfd = 0;   /* Initialize our socket */
+    int           listenfd = -1;  /* Initialize our socket */
     WOLFSSL*      ssl = NULL;
     socklen_t     cliLen;
     socklen_t     len = sizeof(int);
@@ -105,11 +104,11 @@ int main(int argc, char** argv)
     /* Await Datagram */
     ;
 
-    while (cleanup != 1) {
+    while (1) {
         /* Create a UDP/IP socket */
         listenfd = socket(AF_INET, SOCK_DGRAM, 0);
 
-        if (listenfd <= 0 ) {
+        if (listenfd < 0 ) {
             printf("error: cannot create socket: %d\n", listenfd);
             break;
         }
@@ -211,16 +210,19 @@ int main(int argc, char** argv)
         wolfSSL_set_fd(ssl, 0);
         wolfSSL_shutdown(ssl);
         wolfSSL_free(ssl);
+        ssl = NULL;
         close(listenfd);
-        cleanup = 0;
+        listenfd = -1;
 
         printf("Client left cont to idle state\n");
     }
     
-    if (cleanup == 1) {
+    if (ssl != NULL) {
         wolfSSL_set_fd(ssl, 0);
         wolfSSL_shutdown(ssl);
         wolfSSL_free(ssl);
+    }
+    if (listenfd >= 0) {
         close(listenfd);
     }
 

--- a/dtls/server-dtls.c
+++ b/dtls/server-dtls.c
@@ -43,8 +43,6 @@
 static struct sockaddr_in servAddr;     /* our server's address */
 static struct sockaddr_in cliaddr;      /* the client's address */
 
-void sig_handler(const int sig);
-
 int main(int argc, char** argv)
 {
     /* Loc short for "location" */

--- a/pk/rsa/rsa-nb.c
+++ b/pk/rsa/rsa-nb.c
@@ -224,7 +224,7 @@ int main(int argc, char** argv)
     verifySz = ret;
     ret = 0;
 
-    if (signSz == ret && XMEMCMP(plain, in, (size_t)ret)) {
+    if (verifySz != (int)inSz || XMEMCMP(plain, in, inSz) != 0) {
         ret = SIG_VERIFY_E;
     }
 
@@ -242,9 +242,7 @@ prog_end:
     wc_FreeRng(&rng);
     wolfSSL_Cleanup();
 
-    (void)verifySz;
-
-    return 0;
+    return ret;
 #else
     (void)kRsaKey;
 

--- a/psk/client-psk-resume.c
+++ b/psk/client-psk-resume.c
@@ -95,13 +95,15 @@ int main(int argc, char **argv){
     /* converts IPv4 addresses from text to binary form */
     ret = inet_pton(AF_INET, argv[1], &servaddr.sin_addr);
     if (ret != 1){
-        ret = -1; goto exit;
+        ret = -1;
+        goto exit;
     }
 
     /* attempts to make a connection on a socket */
     ret = connect(sockfd, (struct sockaddr *) &servaddr, sizeof(servaddr));
     if (ret != 0 ){
-        ret = -1; goto exit;
+        ret = -1;
+        goto exit;
     }
 
     wolfSSL_Init();  /* initialize wolfSSL */
@@ -109,7 +111,8 @@ int main(int argc, char **argv){
     /* create and initialize WOLFSSL_CTX structure */
     if ((ctx = wolfSSL_CTX_new(wolfTLSv1_2_client_method())) == NULL) {
         fprintf(stderr, "wolfSSL_CTX_new error.\n");
-        ret = -1; goto exit;
+        ret = -1;
+        goto exit;
     }
 
 #ifndef NO_PSK
@@ -122,7 +125,8 @@ int main(int argc, char **argv){
     /* create wolfSSL object after each tcp connect */
     if ( (ssl = wolfSSL_new(ctx)) == NULL) {
         fprintf(stderr, "wolfSSL_new error.\n");
-        ret = -1; goto exit;
+        ret = -1;
+        goto exit;
     }
 
     /* associate the file descriptor with the session */
@@ -131,20 +135,22 @@ int main(int argc, char **argv){
      /* takes inputting string and outputs it to the server */
     if (wolfSSL_write(ssl, sendline, sizeof(sendline)) != sizeof(sendline)) {
         printf("Write Error to Server\n");
-        ret = -1; goto exit;
+        ret = -1;
+        goto exit;
     }
 
     /* flags if the Server stopped before the client could end */
     if (wolfSSL_read(ssl, recvline, MAXLINE) < 0 ) {
         printf("Client: Server Terminated Prematurely!\n");
-        ret = -1; goto exit;
+        ret = -1;
+        goto exit;
     }
 
     /* show message from the server */
     printf("Server Message: %s\n", recvline);
 
     /* Save the session ID to reuse */
-    session   = wolfSSL_get_session(ssl);
+    session   = wolfSSL_get1_session(ssl);
     sslResume = wolfSSL_new(ctx);
 
     /* shut down wolfSSL */
@@ -152,10 +158,21 @@ int main(int argc, char **argv){
 
     /* close connection */
     close(sockfd);
+    sockfd = SOCKET_INVALID;
 
     /* cleanup without wolfSSL_Cleanup() and wolfSSL_CTX_free() for now */
     wolfSSL_free(ssl);
     ssl = NULL;
+
+    if (session == NULL) {
+        ret = -1;
+        goto exit;
+    }
+
+    if (sslResume == NULL) {
+        ret = -1;
+        goto exit;
+    }
 
     /*
      * resume session, start new connection and socket
@@ -213,6 +230,8 @@ exit:
         wolfSSL_free(ssl);      /* Free the wolfSSL object              */
     if (sslResume)
         wolfSSL_free(sslResume);      /* Free the wolfSSL object        */
+    if (session != NULL)
+        wolfSSL_SESSION_free(session);
     if (sockfd != SOCKET_INVALID)
         close(sockfd);          /* Close the socket   */
     if (sock != SOCKET_INVALID)

--- a/tls-options/client-tls-resume.c
+++ b/tls-options/client-tls-resume.c
@@ -29,6 +29,7 @@
 #include <arpa/inet.h>
 #include <netinet/in.h>
 #include <unistd.h>
+#include <netdb.h>
 
 /* wolfSSL */
 #include <wolfssl/options.h>

--- a/tls-options/client-tls-session.c
+++ b/tls-options/client-tls-session.c
@@ -29,6 +29,7 @@
 #include <arpa/inet.h>
 #include <netinet/in.h>
 #include <unistd.h>
+#include <netdb.h>
 
 /* wolfSSL */
 #include <wolfssl/options.h>
@@ -222,7 +223,11 @@ int main(int argc, char **argv)
          * before writing session information
          */  
         if (strcmp(msg, "break") == 0) {
-            session = wolfSSL_get_session(ssl);
+            session = wolfSSL_get1_session(ssl);
+            if (session == NULL) {
+                print_SSL_error("failed wolfSSL_get1_session", ssl);
+                break;
+            }
             ret = write_SESS(session, SAVED_SESS);
             break;
         }

--- a/tls/client-tls-resume.c
+++ b/tls/client-tls-resume.c
@@ -180,6 +180,7 @@ int main(int argc, char** argv)
     wolfSSL_free(ssl);
     ssl = NULL;
     close(sockfd);
+    sockfd = SOCKET_INVALID;
 
 
     /* --------------------------------------- *

--- a/tls/server-tls-nonblocking.c
+++ b/tls/server-tls-nonblocking.c
@@ -228,7 +228,7 @@ int main()
             ret = wolfSSL_accept(ssl);
             err = wolfSSL_get_error(ssl, ret);
             if (err == WOLFSSL_ERROR_WANT_READ)
-                tcp_select(sockfd, SELECT_WAIT_SEC, 1);
+                tcp_select(connd, SELECT_WAIT_SEC, 1);
         } while (err == WOLFSSL_ERROR_WANT_READ || err == WOLFSSL_ERROR_WANT_WRITE);
         if (ret != WOLFSSL_SUCCESS) {
             fprintf(stderr, "wolfSSL_accept error %d (%d)\n", err, ret);
@@ -244,7 +244,7 @@ int main()
             err = wolfSSL_get_error(ssl, ret);
 
             if (err == WOLFSSL_ERROR_WANT_READ)
-                tcp_select(sockfd, SELECT_WAIT_SEC, 1);
+                tcp_select(connd, SELECT_WAIT_SEC, 1);
         }
         while (err == WOLFSSL_ERROR_WANT_READ);
         if (ret < 0) {
@@ -272,7 +272,8 @@ int main()
         do {
             ret = wolfSSL_write(ssl, reply, len);
             err = wolfSSL_get_error(ssl, ret);
-            sleep(1);
+            if (err == WOLFSSL_ERROR_WANT_WRITE)
+                tcp_select(connd, SELECT_WAIT_SEC, 0);
         }
         while (err == WOLFSSL_ERROR_WANT_WRITE);
         if (ret < 0) {
@@ -285,7 +286,7 @@ int main()
             ret = wolfSSL_shutdown(ssl);
             err = wolfSSL_get_error(ssl, 0);
             if (err == WOLFSSL_ERROR_WANT_READ)
-                tcp_select(sockfd, SELECT_WAIT_SEC, 1);
+                tcp_select(connd, SELECT_WAIT_SEC, 1);
         } while (err == WOLFSSL_ERROR_WANT_READ || err == WOLFSSL_ERROR_WANT_WRITE);
 
         /* Cleanup after this connection */


### PR DESCRIPTION
Applied Fenrir fixes and audited for similar errors:

  - Replaced standard C string library calls with wolfSSL macros.
  - Fixed resource leaks on client accept loop failures.
  - Added missing bounds/error checks and corrected condition flows to continue; on errors.
  - clients & servers: Initialized socket/listen descriptors to  -1  (instead of  0 ) to
  closure of  stdin  ( fd 0 ) during cleanup.
  - Fixed a bug in the RSA non-blocking signature verification check by correctly comparing  verifySz  against
  inSz.
  - Assigned socket descriptors to  SOCKET_INVALID  immediately after closing
  - PSK Resume: Added a missing null check on the  sslResume  pointer