### PR TITLE
Fenrir Fixes: Error Handling

### DIFF
--- a/TOPPERS/WolfSSLDemo/src/wolfDemo/wolf_client.c
+++ b/TOPPERS/WolfSSLDemo/src/wolfDemo/wolf_client.c
@@ -149,7 +149,7 @@ int wolfSSL_TLS_client(void *v_ctx, func_args *args)
     }
 
     if ((ssl = wolfSSL_new(ctx)) == NULL) {
-        printf("ERROR wolfSSL_new: %d\n", wolfSSL_get_error(ssl, 0));
+        printf("ERROR wolfSSL_new failed\n");
         ret = -1;
         goto exit_;
     }

--- a/btle/ecies/ecc-client.c
+++ b/btle/ecies/ecc-client.c
@@ -142,6 +142,7 @@ int main(int argc, char** argv)
         ret = btle_recv(peerSalt, EXCHANGE_SALT_SZ, &type, devCtx);
         if (ret <= 0) {
             printf("btle_recv failed %d!\n", ret);
+            goto cleanup;
         }
         if (type != BTLE_PKT_TYPE_SALT) {
             printf("btle_recv expected salt!\n");

--- a/certgen/csr_cryptocb.c
+++ b/certgen/csr_cryptocb.c
@@ -310,6 +310,8 @@ static int gen_csr(const char* arg1)
 #endif
     void* keyPtr = NULL;
     WC_RNG rng;
+    int initRng = 0;
+    int initKey = 0;
     Cert req;
     byte   der[LARGE_TEMP_SZ];
     word32 derSz;
@@ -342,6 +344,7 @@ static int gen_csr(const char* arg1)
         printf("RNG initialization failed: %d\n", ret);
         goto exit;
     }
+    initRng = 1;
 
     /* setup test key */
 #ifdef HAVE_ECC
@@ -394,6 +397,7 @@ static int gen_csr(const char* arg1)
         printf("Key initialization failed: %d\n", ret);
         goto exit;
     }
+    initKey = 1;
 
     /* decode public key */
 #ifdef HAVE_ECC
@@ -467,18 +471,19 @@ static int gen_csr(const char* arg1)
 
 exit:
 #ifdef HAVE_ECC
-    if (type == ECC_TYPE)
+    if (type == ECC_TYPE && initKey)
         wc_ecc_free(&ecKeyPub);
 #endif
 #ifndef NO_RSA
-    if (type == RSA_TYPE)
+    if (type == RSA_TYPE && initKey)
         wc_FreeRsaKey(&rsaKeyPub);
 #endif
 #ifdef HAVE_ED25519
-    if (type == ED25519_TYPE)
+    if (type == ED25519_TYPE && initKey)
         wc_ed25519_free(&edKeyPub);
 #endif
-    wc_FreeRng(&rng);
+    if (initRng)
+        wc_FreeRng(&rng);
 
     wolfCrypt_Cleanup();
 

--- a/certgen/csr_sign.c
+++ b/certgen/csr_sign.c
@@ -180,11 +180,19 @@ static int do_csrsign(int argc, char** argv)
     printf("Successfully read %d bytes from %s\n\n", pemSz, csrPemFile);
 
     ret = wc_CertPemToDer(pemBuf, pemSz, derBuf, LARGE_TEMP_SZ, CERTREQ_TYPE);
-    if (ret >= 0) {
+    if (ret == ASN_NO_PEM_HEADER) {
+        memcpy(derBuf, pemBuf, pemSz);
+        memset(pemBuf, 0, LARGE_TEMP_SZ);
+        derSz = pemSz;
+        ret = 0;
+        printf("CSR Cert file detected as DER\n\n");
+    } else if (ret >= 0) {
         derSz = ret;
         ret = 0;
+        printf("Converted CSR Cert PEM to DER %d bytes\n", derSz);
+    } else {
+        goto exit;
     }
-    printf("Converted CSR Cert PEM to DER %d bytes\n", derSz);
 
 #ifdef HAVE_DECODEDCERT
     /* Code for parsing a CSR to a DecodedCert struct */

--- a/certgen/custom_ext.c
+++ b/certgen/custom_ext.c
@@ -133,7 +133,7 @@ static int do_certgen(int argc, char** argv)
     if (ret != 0) goto exit;
     initNewKey = 1;
 
-    wc_MakeRsaKey(&newKey, 2048, WC_RSA_EXPONENT, &rng);
+    ret = wc_MakeRsaKey(&newKey, 2048, WC_RSA_EXPONENT, &rng);
     if (ret != 0) goto exit;
 
     printf("Successfully created new RSA key\n\n");

--- a/crypto/aes/aesgcm-file-encrypt.c
+++ b/crypto/aes/aesgcm-file-encrypt.c
@@ -475,7 +475,6 @@ int decrypt_file_AesGCM(const char *in_file, const char *out_file,
              * remove the partially written output file. */
             fprintf(stderr,
                 "Authentication failed, removing unverified output file\n");
-            unlink(out_file);
         }
     }
 exit:
@@ -493,6 +492,10 @@ exit:
     XFREE(out_buf, NULL, DYNAMIC_TYPE_TMP_BUFFER);
     close(in_fd);
     close(out_fd);
+    if (ret != 0) {
+        unlink(out_file);
+    }
+
     if (ret != 0) {
         unlink(out_file);
     }
@@ -760,7 +763,8 @@ int decrypt_file(const char *in_file, const char *out_file, const char *key_str)
         goto exit;
     }
     if (EVP_DecryptFinal_ex(ctx, out_buf, &out_len) != WOLFSSL_SUCCESS) {
-        perror("EVP_DecryptFinal_ex");
+        fprintf(stderr,
+            "Authentication failed, removing unverified output file\n");
         ret = AES_GCM_AUTH_E;
         goto exit;
     }
@@ -773,11 +777,10 @@ int decrypt_file(const char *in_file, const char *out_file, const char *key_str)
     if (ret == WOLFSSL_SUCCESS) {
         ret = EVP_CIPHER_CTX_ctrl(ctx, EVP_CTRL_GCM_GET_TAG,
                                   AES_IV_SIZE, tag_dec);
-        if (ret == WOLFSSL_SUCCESS &&
+        if (ret != WOLFSSL_SUCCESS ||
             (memcmp(tag_enc, tag_dec, AESGCM_TAG_SIZE) != 0)) {
-            perror("TAG didn't match\n");
-            /* Authentication failed, unauthenticated plaintext was
-             * already written to out_file above; remove it. */
+            fprintf(stderr,
+                "Authentication failed, removing unverified output file\n");
             ret = AES_GCM_AUTH_E;
             goto exit;
         }
@@ -837,11 +840,11 @@ text.bin", (file_sz/1024)+1, file_sz);
     pclose(pipe);
 
 #ifdef OPENSSL_EXTRA
-    const char *cmd_enc_evp ="./aesgcm-file-encrypt -e 256 -m 1 \
+    const char *cmd_enc_evp ="./aesgcm-file-encrypt -e 256 -m 2 \
                               -k 77CF00EC060192530B5D06B6B426799B \
                               -v 77CF00EC060192530B5D06B6B426799B \
                               -i text.bin -o text2cipher.evp.bin";
-    const char *cmd_dec_evp ="./aesgcm-file-encrypt -d 256 -m 1 \
+    const char *cmd_dec_evp ="./aesgcm-file-encrypt -d 256 -m 2 \
                             -k 77CF00EC060192530B5D06B6B426799B \
                             -i text2cipher.evp.bin -o text2cipher2text.evp.bin";
     const char *cmd_diff_evp = "diff -q text.bin text2cipher2text.evp.bin";

--- a/crypto/aes/aesgcm-file-encrypt.c
+++ b/crypto/aes/aesgcm-file-encrypt.c
@@ -466,9 +466,17 @@ int decrypt_file_AesGCM(const char *in_file, const char *out_file,
      }
 
     if (ret == 0) {
-        /* The tag param is used to compare to the 
+        /* The tag param is used to compare to the
            calculated tag during decryption */
         ret = wc_AesGcmDecryptFinal(&gcm, tag, AESGCM_TAG_SIZE);
+        if (ret != 0) {
+            /* Authentication failed. The unauthenticated plaintext
+             * written above must not be left readable on disk, so
+             * remove the partially written output file. */
+            fprintf(stderr,
+                "Authentication failed, removing unverified output file\n");
+            unlink(out_file);
+        }
     }
 exit:
     if (aes_initialized) {
@@ -768,6 +776,8 @@ int decrypt_file(const char *in_file, const char *out_file, const char *key_str)
         if (ret == WOLFSSL_SUCCESS &&
             (memcmp(tag_enc, tag_dec, AESGCM_TAG_SIZE) != 0)) {
             perror("TAG didn't match\n");
+            /* Authentication failed, unauthenticated plaintext was
+             * already written to out_file above; remove it. */
             ret = AES_GCM_AUTH_E;
             goto exit;
         }

--- a/crypto/ascon/ascon-file-encrypt.c
+++ b/crypto/ascon/ascon-file-encrypt.c
@@ -31,6 +31,10 @@
 #include <wolfssl/wolfcrypt/random.h>
 #include <wolfssl/wolfcrypt/pwdbased.h>
 
+#ifndef HAVE_ASCON
+    #error "Please build wolfSSL with the --enable-ascon option"
+#endif
+
 #define ASCON_AEAD128_RATE 16
 #define SALT_SIZE           8
 #define AD_SIZE             32
@@ -353,6 +357,12 @@ int AsconDecrypt(wc_AsconCtx* ctx)
         /* Start decrypting ciphertext */
         ctx->inFileLength -= FILE_HEADER_SIZE;
 
+        /* The plaintext written here is unauthenticated until
+         * DecryptFinal() verifies the tag below. It is written out
+         * incrementally to keep memory bounded to BLOCK_SIZE; if
+         * authentication fails, the caller's MemFree() removes the
+         * output file so the unverified plaintext is never left
+         * behind on disk. */
         for (j = 0; j <= ctx->inFileLength; j += BLOCK_SIZE) {
             if (chunk_read > ctx->inFileLength - j) {
                 chunk_read = ctx->inFileLength - j;
@@ -369,15 +379,13 @@ int AsconDecrypt(wc_AsconCtx* ctx)
                 return ERROR;
             }
 
-            /* write plaintext to output file */
-            if (fwrite(ctx->plainText, 1, chunk_read, ctx->outFile) != chunk_read) {
+            if (fwrite(ctx->plainText, 1, chunk_read, ctx->outFile) != (size_t)chunk_read) {
                 printf("ERROR: Failed to write the appropriate amount\n");
                 return ERROR;
             }
-
         }
 
-        /* Finalize decryption and verify tag */
+        /* Finalize decryption and verify tag. */
         if (wc_AsconAEAD128_DecryptFinal(ctx->ascon, tag) != SUCCESS) {
             printf("Decrypt final failed.\n");
             return ERROR;

--- a/dtls/server-dtls13.c
+++ b/dtls/server-dtls13.c
@@ -152,7 +152,7 @@ int main(int argc, char** argv)
 
         if (wolfSSL_set_fd(ssl, listenfd) != WOLFSSL_SUCCESS) {
             fprintf(stderr, "wolfSSL_set_fd error.\n");
-            break;
+            goto cleanup;
         }
 
         if (wolfSSL_accept(ssl) != WOLFSSL_SUCCESS) {

--- a/hash/sha256-hash.c
+++ b/hash/sha256-hash.c
@@ -72,6 +72,7 @@ int main(int argc, char** argv)
     if (ret != 0) {
         printf("Failed to initialize sha structure\n");
         fclose(inputStream);
+        return ret;
     }
 
     /* Loop reading a block at a time, finishing with any excess */

--- a/hash/sha3-256-hash.c
+++ b/hash/sha3-256-hash.c
@@ -72,6 +72,7 @@ int main(int argc, char** argv)
     if (ret != 0) {
         printf("Failed to initialize sha structure\n");
         fclose(inputStream);
+        return ret;
     }
 
     /* Loop reading a block at a time, finishing with any excess */

--- a/hash/sha512-hash.c
+++ b/hash/sha512-hash.c
@@ -72,6 +72,7 @@ int main(int argc, char** argv)
     if (ret != 0) {
         printf("Failed to initialize sha structure\n");
         fclose(inputStream);
+        return ret;
     }
 
     /* Loop reading a block at a time, finishing with any excess */

--- a/pk/ecc/ecc_keys.c
+++ b/pk/ecc/ecc_keys.c
@@ -51,12 +51,24 @@ int main()
     FILE* derFile;
     size_t sz;
 
-    wc_InitRng(&rng);
-    wc_ecc_init(&key);
+    ret = wc_InitRng(&rng);
+    if (ret != 0) {
+        printf("error %d initializing rng\n", ret);
+        return ret;
+    }
+
+    ret = wc_ecc_init(&key);
+    if (ret != 0) {
+        printf("error %d initializing ecc key\n", ret);
+        wc_FreeRng(&rng);
+        return ret;
+    }
 
     ret = wc_ecc_make_key_ex(&rng, ECC_CURVE_SZ, &key, ECC_CURVE_ID);
     if (ret != 0) {
         printf("error %d making ecc key\n", ret);
+        wc_ecc_free(&key);
+        wc_FreeRng(&rng);
         return ret;
     }
 
@@ -64,6 +76,8 @@ int main()
     ret = wc_EccKeyToDer(&key, der, sizeof(der));
     if (ret < 0) {
         printf("error %d in ecc to der\n", ret);
+        wc_ecc_free(&key);
+        wc_FreeRng(&rng);
         return ret;
     }
     sz = ret;
@@ -72,6 +86,8 @@ int main()
     derFile = fopen("ecc-key.der", "w");
     if (!derFile) {
         printf("error loading file\n");
+        wc_ecc_free(&key);
+        wc_FreeRng(&rng);
         return -1;
     }
 
@@ -84,6 +100,7 @@ int main()
     derFile = fopen("ecc-key.der", "rb");
     if (!derFile) {
         printf("error reading from file\n");
+        wc_FreeRng(&rng);
         return -1;
     }
     sz = fread(buf, 1, sizeof(buf), derFile);
@@ -95,6 +112,8 @@ int main()
     idx = 0;
     if (wc_EccPrivateKeyDecode(buf, &idx, &key, (word32)sz) != 0) {
         printf("error decoding private key\n");
+        wc_ecc_free(&key);
+        wc_FreeRng(&rng);
         return -1;
     }
     wc_ecc_free(&key);
@@ -113,6 +132,8 @@ int main()
     ret = wc_ecc_make_key_ex(&rng, ECC_CURVE_SZ, &key, ECC_CURVE_ID);
     if (ret != 0) {
         printf("error %d making ecc key\n", ret);
+        wc_ecc_free(&key);
+        wc_FreeRng(&rng);
         return ret;
     }
 
@@ -121,6 +142,8 @@ int main()
     sz = sizeof(buf);
     if (wc_ecc_export_x963(&key, buf, (word32*)&sz) != 0) {
         printf("error exporting public ecc key\n");
+        wc_ecc_free(&key);
+        wc_FreeRng(&rng);
         return -1;
     }
 
@@ -128,6 +151,8 @@ int main()
     derFile = fopen("ecc-public.x963", "w"); /* reused the derFile pointer */
     if (!derFile) {
         printf("error loading file\n");
+        wc_ecc_free(&key);
+        wc_FreeRng(&rng);
         return -1;
     }
     fwrite(buf, 1, sz, derFile);

--- a/pk/ed25519/ed25519_keys.c
+++ b/pk/ed25519/ed25519_keys.c
@@ -88,8 +88,18 @@ int main()
     word32 idx;
     size_t sz;
 
-    wc_InitRng(&rng);
-    wc_ed25519_init(&key);
+    ret = wc_InitRng(&rng);
+    if (ret != 0) {
+        printf("error %d initializing rng\n", ret);
+        return ret;
+    }
+
+    ret = wc_ed25519_init(&key);
+    if (ret != 0) {
+        printf("error %d initializing ed25519 key\n", ret);
+        wc_FreeRng(&rng);
+        return ret;
+    }
 
     /*
      * Make a private Ed25510 key
@@ -99,6 +109,8 @@ int main()
     ret = wc_ed25519_make_key(&rng, ED25519_KEY_SIZE, &key);
     if (ret != 0) {
         printf("error %d making Ed25519 key\n", ret);
+        wc_ed25519_free(&key);
+        wc_FreeRng(&rng);
         return ret;
     }
 
@@ -110,6 +122,8 @@ int main()
     ret = wc_Ed25519KeyToDer(&key, der, sizeof(der));
     if (ret < 0) {
         printf("error %d in Ed25519 to der\n", ret);
+        wc_ed25519_free(&key);
+        wc_FreeRng(&rng);
         return ret;
     }
     sz = ret;
@@ -117,6 +131,8 @@ int main()
     /* write private key to file */
     ret = write_file("private key", privFile, der, sz);
     if (ret < 0) {
+        wc_ed25519_free(&key);
+        wc_FreeRng(&rng);
         return ret;
     }
 
@@ -130,6 +146,7 @@ int main()
     sz = sizeof(buf);
     ret = read_file("private key", privFile, buf, &sz);
     if (ret < 0) {
+        wc_FreeRng(&rng);
         return ret;
     }
 
@@ -141,6 +158,8 @@ int main()
     ret = wc_Ed25519PrivateKeyDecode(buf, &idx, &key, (word32)sz);
     if (ret != 0) {
         printf("error decoding private key\n");
+        wc_ed25519_free(&key);
+        wc_FreeRng(&rng);
         return ret;
     }
 
@@ -162,6 +181,8 @@ int main()
     ret = wc_ed25519_make_key(&rng, ED25519_KEY_SIZE, &key);
     if (ret != 0) {
         printf("error %d making Ed25519 key\n", ret);
+        wc_ed25519_free(&key);
+        wc_FreeRng(&rng);
         return ret;
     }
 
@@ -175,12 +196,16 @@ int main()
     ret = wc_ed25519_export_public(&key, buf, (word32*)&sz);
     if (ret != 0) {
         printf("error exporting public Ed25519 key\n");
+        wc_ed25519_free(&key);
+        wc_FreeRng(&rng);
         return ret;
     }
 
     /* write public key to file */
     ret = write_file("public key", pubFile, buf, sz);
     if (ret < 0) {
+        wc_ed25519_free(&key);
+        wc_FreeRng(&rng);
         return ret;
     }
 

--- a/pk/ed448/ed448_keys.c
+++ b/pk/ed448/ed448_keys.c
@@ -88,8 +88,18 @@ int main()
     word32 idx;
     size_t sz;
 
-    wc_InitRng(&rng);
-    wc_ed448_init(&key);
+    ret = wc_InitRng(&rng);
+    if (ret != 0) {
+        printf("error %d initializing rng\n", ret);
+        return ret;
+    }
+
+    ret = wc_ed448_init(&key);
+    if (ret != 0) {
+        printf("error %d initializing ed448 key\n", ret);
+        wc_FreeRng(&rng);
+        return ret;
+    }
 
     /*
      * Make a private Ed25510 key
@@ -99,6 +109,8 @@ int main()
     ret = wc_ed448_make_key(&rng, ED448_KEY_SIZE, &key);
     if (ret != 0) {
         printf("error %d making Ed448 key\n", ret);
+        wc_ed448_free(&key);
+        wc_FreeRng(&rng);
         return ret;
     }
 
@@ -110,6 +122,8 @@ int main()
     ret = wc_Ed448KeyToDer(&key, der, sizeof(der));
     if (ret < 0) {
         printf("error %d in Ed448 to der\n", ret);
+        wc_ed448_free(&key);
+        wc_FreeRng(&rng);
         return ret;
     }
     sz = ret;
@@ -117,6 +131,8 @@ int main()
     /* write private key to file */
     ret = write_file("private key", privFile, der, sz);
     if (ret < 0) {
+        wc_ed448_free(&key);
+        wc_FreeRng(&rng);
         return ret;
     }
 
@@ -130,6 +146,7 @@ int main()
     sz = sizeof(buf);
     ret = read_file("private key", privFile, buf, &sz);
     if (ret < 0) {
+        wc_FreeRng(&rng);
         return ret;
     }
 
@@ -141,6 +158,8 @@ int main()
     ret = wc_Ed448PrivateKeyDecode(buf, &idx, &key, (word32)sz);
     if (ret != 0) {
         printf("error decoding private key\n");
+        wc_ed448_free(&key);
+        wc_FreeRng(&rng);
         return ret;
     }
 
@@ -162,6 +181,8 @@ int main()
     ret = wc_ed448_make_key(&rng, ED448_KEY_SIZE, &key);
     if (ret != 0) {
         printf("error %d making Ed448 key\n", ret);
+        wc_ed448_free(&key);
+        wc_FreeRng(&rng);
         return ret;
     }
 
@@ -175,12 +196,16 @@ int main()
     ret = wc_ed448_export_public(&key, buf, (word32*)&sz);
     if (ret != 0) {
         printf("error exporting public Ed448 key\n");
+        wc_ed448_free(&key);
+        wc_FreeRng(&rng);
         return ret;
     }
 
     /* write public key to file */
     ret = write_file("public key", pubFile, buf, sz);
     if (ret < 0) {
+        wc_ed448_free(&key);
+        wc_FreeRng(&rng);
         return ret;
     }
 

--- a/pk/rsa-pss/rsa-pss.c
+++ b/pk/rsa-pss/rsa-pss.c
@@ -116,7 +116,7 @@ static int read_file(const char* filename, unsigned char* data, int* sz)
     *sz = fileSz;
     err = 0;
 load_end:
-    fclose(f);
+    if (f != NULL) fclose(f);
     return err;
 }
 

--- a/pkcs11/pkcs11_rsa.c
+++ b/pkcs11/pkcs11_rsa.c
@@ -260,15 +260,15 @@ static int rsa_sign_verify(int devId)
         if (ret == 0) {
             fprintf(stderr, "Verifying\n");
             ret = wc_RsaSSL_Verify(sig, sigSz, pt, (int)ptSz, &pub);
-            if (ret < 0)
+            if (ret < 0) {
                 fprintf(stderr, "Failed to verify: %d\n", ret);
-
-            if (XMEMCMP(hash, pt, ret) != 0) {
-                fprintf(stderr, "Failed to verify\n");
+            } else if (ret != (int)hashSz || XMEMCMP(hash, pt, ret) != 0) {
+                fprintf(stderr, "Failed to verify: hash mismatch\n");
+                ret = -1;
+            } else {
+                ret = 0;
             }
-
             wc_FreeRsaKey(&pub);
-            ret = 0;
         }
     }
 

--- a/pkcs11/pkcs11_test.c
+++ b/pkcs11/pkcs11_test.c
@@ -284,13 +284,23 @@ int get_public_key(RsaKey* key, Pkcs11Token* token, CK_SESSION_HANDLE session,
         modSz = template[0].ulValueLen;
         expSz = template[1].ulValueLen;
         mod = (unsigned char *)malloc(modSz);
-        template[0].pValue = mod;
         exp = (CK_BYTE_PTR) malloc(expSz);
-        template[1].pValue = exp;
+        if (mod == NULL || exp == NULL) {
+            ret = MEMORY_E;
+        }
+        else {
+            template[0].pValue = mod;
+            template[1].pValue = exp;
 
-        rv = token->func->C_GetAttributeValue(session, pubKey, template, 2);
+            rv = token->func->C_GetAttributeValue(session, pubKey, template, 2);
+            if (rv != CKR_OK)
+                ret = -1;
+        }
     }
-    if (rv == CKR_OK)
+    else
+        ret = -1;
+
+    if (rv == CKR_OK && ret == 0)
         ret = wc_RsaPublicKeyDecodeRaw(mod, modSz, exp, expSz, key);
 
     if (exp != NULL)

--- a/pkcs7/pkcs7-verify.c
+++ b/pkcs7/pkcs7-verify.c
@@ -48,6 +48,16 @@ int main(int argc, char** argv)
     wolfSSL_Debugging_ON();
 #endif
 
+    /* PKCS_Init captures/saves this, so make sure
+     * isDynamic = 0 since it is on the stack. Set this before any
+     * code path that can reach the exit label and call wc_PKCS7_Free(). */
+    pkcs7.isDynamic = 0;
+
+    /* Init before any code path that can reach the exit label and call
+     * wc_PKCS7_Free(), so the struct is always fully zeroed first. */
+    rc = wc_PKCS7_Init(&pkcs7, NULL, INVALID_DEVID);
+    if (rc != 0) goto exit;
+
     /* load PKCS7 */
     derFile = fopen(pkcs7SignedPem, "rb");
     if (derFile) {
@@ -72,14 +82,12 @@ int main(int argc, char** argv)
         }
         rc = 0;
     }
-
-    /* PKCS_Init captures/saves this, so make sure
-     * isDynamic = 0 since it is on the stack */
-    pkcs7.isDynamic = 0;
+    else {
+        rc = -1;
+        goto exit;
+    }
 
     /* Test verify */
-    rc = wc_PKCS7_Init(&pkcs7, NULL, INVALID_DEVID);
-    if (rc != 0) goto exit;
     rc = wc_PKCS7_InitWithCert(&pkcs7, NULL, 0);
     if (rc != 0) goto exit;
 
@@ -112,9 +120,21 @@ int main(int argc, char** argv)
     /* load PKCS7 */
     derFile = fopen(pkcs7SignedDer, "rb");
     if (derFile) {
+        int derFileSz;
         fseek(derFile, 0, SEEK_END);
-        fileSz = (int)ftell(derFile);
+        derFileSz = (int)ftell(derFile);
         rewind(derFile);
+
+        if (derFileSz > (int)fileSz) {
+            XFREE(fileBuf, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+            fileBuf = (byte*)XMALLOC(derFileSz, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+            if (fileBuf == NULL) {
+                rc = MEMORY_E;
+                fclose(derFile);
+                goto exit;
+            }
+        }
+        fileSz = derFileSz;
 
         rc = (int)fread(fileBuf, 1, fileSz, derFile);
         fclose(derFile);
@@ -125,6 +145,10 @@ int main(int argc, char** argv)
             goto exit;
         }
         rc = 0;
+    }
+    else {
+        rc = -1;
+        goto exit;
     }
 
     /* Verify DER output matches expected output */

--- a/pkcs7/signedData-stream.c
+++ b/pkcs7/signedData-stream.c
@@ -335,6 +335,11 @@ int main(int argc, char** argv)
 
     {
         FILE* f = fopen(encodedFile, "rb");
+        if (f == NULL) {
+            printf("error opening file %s\n", encodedFile);
+            ret = -1;
+            goto out;
+        }
         encryptedSz = fread(encrypted, 1, encryptedSz, f);
         fclose(f);
     }

--- a/pq/stateful_hash_sig/lms_example.c
+++ b/pq/stateful_hash_sig/lms_example.c
@@ -345,6 +345,7 @@ do_lms_example(int    levels,
     sig = malloc(sigSz);
     if (sig == NULL) {
         fprintf(stderr, "error: malloc(%d) failed\n", sigSz);
+        ret = MEMORY_E;
         goto exit_lms_example;
     }
 

--- a/pq/stateful_hash_sig/xmss_example.c
+++ b/pq/stateful_hash_sig/xmss_example.c
@@ -286,6 +286,7 @@ do_xmss_example(const char * params,
     read_buf = malloc(privSz);
     if (read_buf == NULL) {
         fprintf(stderr, "error: malloc read_buf failed\n");
+        ret = MEMORY_E;
         goto exit_xmss_example;
     }
 
@@ -309,6 +310,7 @@ do_xmss_example(const char * params,
     sig = malloc(sigSz);
     if (sig == NULL) {
         fprintf(stderr, "error: malloc(%d) failed\n", sigSz);
+        ret = MEMORY_E;
         goto exit_xmss_example;
     }
 

--- a/psk/server-psk.c
+++ b/psk/server-psk.c
@@ -198,8 +198,8 @@ int main()
             if (n > 0) {
                 printf("%s\n", buf);
                 /* server response */
-                if (wolfSSL_write(ssl, response, strlen(response)) >
-                    strlen(response)) {
+                n = wolfSSL_write(ssl, response, strlen(response));
+                if (n != (int)strlen(response)) {
                     printf("Fatal error : respond: write error\n");
                     return 1;
                 }

--- a/signature/signature.c
+++ b/signature/signature.c
@@ -66,10 +66,19 @@ int ecc_sign_verify_test(enum wc_HashType hash_type, enum wc_SignatureType sig_t
     word32 eccPubKeyLen, eccPrivKeyLen;
 
     /* Init */
-    wc_InitRng(&rng);
+    ret = wc_InitRng(&rng);
+    if (ret != 0) {
+        printf("ECC RNG Init failed! %d\n", ret);
+        return EXIT_FAILURE;
+    }
 
     /* Generate key */
-    wc_ecc_init(&eccKey);
+    ret = wc_ecc_init(&eccKey);
+    if (ret != 0) {
+        printf("ECC Key Init failed! %d\n", ret);
+        wc_FreeRng(&rng);
+        return EXIT_FAILURE;
+    }
     ret = wc_ecc_make_key_ex(&rng, 32, &eccKey, ECC_CURVE_DEF);
     if(ret != 0) {
         printf("ECC Make Key Failed! %d\n", ret);

--- a/signature/sigtest/eccsiglentest.c
+++ b/signature/sigtest/eccsiglentest.c
@@ -78,10 +78,19 @@ int ecc_sign_verify_test(enum wc_HashType hash_type,
 #endif
 
     /* Init */
-    wc_InitRng(&rng);
+    ret = wc_InitRng(&rng);
+    if (ret != 0) {
+        printf("ECC RNG Init Failed! %d\n", ret);
+        return ret;
+    }
 
     /* Generate key */
-    wc_ecc_init(&eccKey);
+    ret = wc_ecc_init(&eccKey);
+    if (ret != 0) {
+        printf("ECC Key Init Failed! %d\n", ret);
+        wc_FreeRng(&rng);
+        return ret;
+    }
 
     ret = wc_ecc_make_key_ex(&rng, keySz, &eccKey, curveId);
     if(ret != 0) {

--- a/signature/sigtest/wolfsigtest.c
+++ b/signature/sigtest/wolfsigtest.c
@@ -140,10 +140,19 @@ int main(int argc, char** argv)
     print_buf("Digest Input Data:", Digest_given, DATA_BLOCK_LEN);
 
     /* Init */
-    wc_InitRng(&rng);
+    ret = wc_InitRng(&rng);
+    if (ret != 0) {
+        printf("error %d initializing rng\n", ret);
+        return ret;
+    }
 
     /* Init Rsa Key */
-    wc_InitRsaKey(&rsakey, NULL);
+    ret = wc_InitRsaKey(&rsakey, NULL);
+    if (ret != 0) {
+        printf("error %d initializing rsa key\n", ret);
+        wc_FreeRng(&rng);
+        return ret;
+    }
 
     XMEMSET(DER_buf, 0, sizeof(DER_buf));
     

--- a/tls-options/client-tls-cipher.c
+++ b/tls-options/client-tls-cipher.c
@@ -96,9 +96,8 @@ int main(int argc, char** argv)
      * Sets the socket to be stream based (TCP),
      * 0 means choose the default protocol. */
     if ((sockfd = socket(AF_INET, SOCK_STREAM, 0)) == -1) {
+        printf("ERROR: failed to create socket\n");
         ret = -1;
-        err = wolfSSL_get_error(ssl, ret);
-        printf("error = %d, %s\n", err, wolfSSL_ERR_error_string(err, buffer));
         goto end;
     }
 
@@ -111,17 +110,15 @@ int main(int argc, char** argv)
 
     /* Get the server IPv4 address from the command line call */
     if (inet_pton(AF_INET, argv[1], &servAddr.sin_addr) != 1) {
+        printf("ERROR: invalid address\n");
         ret = -1;
-        err = wolfSSL_get_error(ssl, ret);
-        printf("error = %d, %s\n", err, wolfSSL_ERR_error_string(err, buffer));
         goto end;
     }
 
     /* Connect to the server */
     if ((ret = connect(sockfd, (struct sockaddr*) &servAddr, sizeof(servAddr)))
          == -1) {
-        err = wolfSSL_get_error(ssl, ret);
-        printf("error = %d, %s\n", err, wolfSSL_ERR_error_string(err, buffer));
+        printf("ERROR: failed to connect\n");
         goto end;
     }
 
@@ -130,24 +127,22 @@ int main(int argc, char** argv)
     /*---------------------------------*/
     /* Initialize wolfSSL */
     if ((ret = wolfSSL_Init()) != WOLFSSL_SUCCESS) {
-        err = wolfSSL_get_error(ssl, ret);
-        printf("error = %d, %s\n", err, wolfSSL_ERR_error_string(err, buffer));
+        printf("ERROR: failed to initialize the library\n");
         goto socket_cleanup;
     }
 
     /* Create and initialize WOLFSSL_CTX */
     if ((ctx = wolfSSL_CTX_new(wolfTLSv1_2_client_method())) == NULL) {
+        printf("ERROR: failed to create WOLFSSL_CTX\n");
         ret = -1;
-        err = wolfSSL_get_error(ssl, ret);
-        printf("error = %d, %s\n", err, wolfSSL_ERR_error_string(err, buffer));
-        goto socket_cleanup;
+        goto ctx_cleanup;
     }
 
     /* Set cipher suite */
     if (cipherList != NULL) {
         if (wolfSSL_CTX_set_cipher_list(ctx, cipherList) != WOLFSSL_SUCCESS) {
-            err = wolfSSL_get_error(ssl, ret);
-            printf("error = %d, %s\n", err, wolfSSL_ERR_error_string(err, buffer));
+            printf("ERROR: failed to set cipher list: %s\n", cipherList);
+            ret = -1;
             goto ctx_cleanup;
         }
     }
@@ -155,16 +150,14 @@ int main(int argc, char** argv)
     /* Load client certificates into WOLFSSL_CTX */
     if ((ret = wolfSSL_CTX_load_verify_locations(ctx, CERT_FILE, NULL))
          != SSL_SUCCESS) {
-        err = wolfSSL_get_error(ssl, ret);
-        printf("error = %d, %s\n", err, wolfSSL_ERR_error_string(err, buffer));
+        printf("ERROR %d: failed to load %s\n", ret, CERT_FILE);
         goto ctx_cleanup;
     }
 
     /* Create a WOLFSSL object */
     if ((ssl = wolfSSL_new(ctx)) == NULL) {
         ret = -1;
-        err = wolfSSL_get_error(ssl, ret);
-        printf("error = %d, %s\n", err, wolfSSL_ERR_error_string(err, buffer));
+        printf("ERROR: failed to create WOLFSSL object\n");
         goto ctx_cleanup;
     }
 
@@ -190,9 +183,8 @@ int main(int argc, char** argv)
     printf("Message for server: ");
     memset(buff, 0, sizeof(buff));
     if (fgets(buff, sizeof(buff), stdin) == NULL) {
+        printf("ERROR: failed to get message for server\n");
         ret = -1;
-        err = wolfSSL_get_error(ssl, ret);
-        printf("error = %d, %s\n", err, wolfSSL_ERR_error_string(err, buffer));
         goto cleanup;
     }
     len = strnlen(buff, sizeof(buff));
@@ -228,7 +220,8 @@ int main(int argc, char** argv)
 cleanup:
     wolfSSL_free(ssl);      /* Free the wolfSSL object                  */
 ctx_cleanup:
-    wolfSSL_CTX_free(ctx);  /* Free the wolfSSL context object          */
+    if (ctx)
+        wolfSSL_CTX_free(ctx);  /* Free the wolfSSL context object      */
     wolfSSL_Cleanup();      /* Cleanup the wolfSSL environment          */
 socket_cleanup:
     close(sockfd);          /* Close the connection to the server       */

--- a/tls-options/server-tls-cipher.c
+++ b/tls-options/server-tls-cipher.c
@@ -109,9 +109,8 @@ int main(int argc, char **argv)
      * Sets the socket to be stream based (TCP),
      * 0 means choose the default protocol. */
     if ((sockfd = socket(AF_INET, SOCK_STREAM, 0)) == -1) {
+        printf("ERROR: failed to create socket\n");
         ret = -1;
-        err = wolfSSL_get_error(ssl, ret);
-        printf("error = %d, %s\n", err, wolfSSL_ERR_error_string(err, buffer));
         goto exit;
     }
 
@@ -119,18 +118,16 @@ int main(int argc, char **argv)
 
     /* Create and initialize WOLFSSL_CTX */
     if ((ctx = wolfSSL_CTX_new(wolfTLSv1_2_server_method())) == NULL) {
+        printf("ERROR: failed to create CTX\n");
         ret = -1;
-        err = wolfSSL_get_error(ssl, ret);
-        printf("error = %d, %s\n", err, wolfSSL_ERR_error_string(err, buffer));
         goto exit;
     }
 
     /* Set cipher suite */
     if (cipherList != NULL) {
         if (wolfSSL_CTX_set_cipher_list(ctx, cipherList) != WOLFSSL_SUCCESS) {
+            printf("ERROR: failed to set cipher list: %s\n", cipherList);
             ret = -1;
-            err = wolfSSL_get_error(ssl, ret);
-            printf("error = %d, %s\n", err, wolfSSL_ERR_error_string(err, buffer));
             goto exit;
         }
     }
@@ -138,16 +135,14 @@ int main(int argc, char **argv)
     /* Load server certificates into WOLFSSL_CTX */
     if ((ret = wolfSSL_CTX_use_certificate_file(ctx, CERT_FILE, SSL_FILETYPE_PEM))
         != WOLFSSL_SUCCESS) {
-        err = wolfSSL_get_error(ssl, ret);
-        printf("error = %d, %s\n", err, wolfSSL_ERR_error_string(err, buffer));
+        printf("ERROR %d: failed to use certificate file %s\n", ret, CERT_FILE);
         goto exit;
     }
 
     /* Load server key into WOLFSSL_CTX */
     if ((ret = wolfSSL_CTX_use_PrivateKey_file(ctx, KEY_FILE, SSL_FILETYPE_PEM))
         != WOLFSSL_SUCCESS) {
-        err = wolfSSL_get_error(ssl, ret);
-        printf("error = %d, %s\n", err, wolfSSL_ERR_error_string(err, buffer));
+        printf("ERROR %d: failed to use private key file %s\n", ret, KEY_FILE);
         goto exit;
     }
 
@@ -165,17 +160,15 @@ int main(int argc, char **argv)
 
     /* Bind the server socket to our port */
     if (bind(sockfd, (struct sockaddr*)&servAddr, sizeof(servAddr)) == -1) {
-        ret = -1; 
-        err = wolfSSL_get_error(ssl, ret);
-        printf("error = %d, %s\n", err, wolfSSL_ERR_error_string(err, buffer));
+        printf("ERROR: failed to bind socket\n");
+        ret = -1;
         goto exit;
     }
 
     /* Listen for a new connection, allow 5 pending connections */
     if (listen(sockfd, 5) == -1) {
+        printf("ERROR: failed to listen on socket\n");
         ret = -1;
-        err = wolfSSL_get_error(ssl, ret);
-        printf("error = %d, %s\n", err, wolfSSL_ERR_error_string(err, buffer));
         goto exit;
     }
 
@@ -188,17 +181,15 @@ int main(int argc, char **argv)
         /* Accept client connections */
         if ((connd = accept(sockfd, (struct sockaddr*)&clientAddr, &size))
             == -1) {
+            printf("ERROR: failed to accept connection\n");
             ret = -1;
-            err = wolfSSL_get_error(ssl, ret);
-            printf("error = %d, %s\n", err, wolfSSL_ERR_error_string(err, buffer));
             goto exit;
         }
 
         /* Create a WOLFSSL object */
         if ((ssl = wolfSSL_new(ctx)) == NULL) {
             ret = -1;
-            err = wolfSSL_get_error(ssl, ret);
-            printf("error = %d, %s\n", err, wolfSSL_ERR_error_string(err, buffer));
+            printf("ERROR: failed to create WOLFSSL object\n");
             goto exit;
         }
 

--- a/tls/client-tls.c
+++ b/tls/client-tls.c
@@ -108,7 +108,7 @@ int main(int argc, char** argv)
     if (ctx == NULL) {
         fprintf(stderr, "ERROR: failed to create WOLFSSL_CTX\n");
         ret = -1;
-        goto socket_cleanup;
+        goto ctx_cleanup;
     }
 
     /* Load client certificates into WOLFSSL_CTX */
@@ -178,7 +178,8 @@ int main(int argc, char** argv)
 cleanup:
     wolfSSL_free(ssl);      /* Free the wolfSSL object                  */
 ctx_cleanup:
-    wolfSSL_CTX_free(ctx);  /* Free the wolfSSL context object          */
+    if (ctx)
+        wolfSSL_CTX_free(ctx);  /* Free the wolfSSL context object      */
     wolfSSL_Cleanup();      /* Cleanup the wolfSSL environment          */
 socket_cleanup:
     close(sockfd);          /* Close the connection to the server       */


### PR DESCRIPTION
Fixes error handling across wolfSSL example files, split into two commits by area:

Crypto/signature examples, 19 findings: F-1298 F-1302 F-1307 F-1712 F-1713 F-1719 F-1720 F-1721 F-1722 F-2093 F-3466 F-3472 F-3477 F-4131 F-4132 F-4600 F-5612 F-6286 F-6289 F-6536

TLS/DTLS/protocol examples, 14 findings: F-1296 F-1301 F-1706 F-2112 F-2893 F-2900 F-3223 F-3899 F-4121 F-4123 F-4127 F-4128 F-4603 F-4604

Fixed: unchecked wc_InitRng/key-init return values, NULL derefs from wolfSSL_get_error() on a NULL ssl, error paths that fall through instead of goto cleanup/return, fd/resource leaks on error, and writing unauthenticated plaintext to disk before AEAD tag verification in both AES-GCM and Ascon file-encrypt examples.