### PR TITLE
Fix NULL check after wolfSSL_new to test the returned ssl object

### DIFF
--- a/dtls/memory-bio-dtls.c
+++ b/dtls/memory-bio-dtls.c
@@ -92,7 +92,7 @@ static void* client_thread(void* args)
     }
 
     cli_ssl = wolfSSL_new(cli_ctx);
-    if (cli_ctx == NULL) {
+    if (cli_ssl == NULL) {
         err_sys("bad client new");
     }
 
@@ -170,7 +170,7 @@ int main()
     }
 
     srv_ssl = wolfSSL_new(srv_ctx);
-    if (srv_ctx == NULL) {
+    if (srv_ssl == NULL) {
         err_sys("bad server new");
     }
 


### PR DESCRIPTION
Check cli_ssl and srv_ssl instead of the unchanged cli_ctx/srv_ctx so a failed wolfSSL_new is detected rather than dereferenced.