### PR TITLE
Fix operator precedence in wolfSSL_connect return check

### DIFF
--- a/tls/client-tls-writedup.c
+++ b/tls/client-tls-writedup.c
@@ -189,7 +189,7 @@ int main(int argc, char** argv)
     wolfSSL_set_fd(read_ssl, sockfd);
 
     /* Connect to wolfSSL on the server side */
-    if ((ret = wolfSSL_connect(read_ssl) != SSL_SUCCESS)) {
+    if ((ret = wolfSSL_connect(read_ssl)) != SSL_SUCCESS) {
         fprintf(stderr, "ERROR: failed to connect to wolfSSL\n");
         goto exit;
     }


### PR DESCRIPTION
Parenthesize the assignment so ret receives the actual return value rather than the boolean result of the != comparison.