### PR TITLE
Fenrir Fixes: Platform Specific

### DIFF
--- a/RPi-Pico/src/time.c
+++ b/RPi-Pico/src/time.c
@@ -36,12 +36,12 @@ int time_init()
     }
     printf("%d, %d, %d, %d, %d, %d\n",
            t.tm_year, t.tm_mon, t.tm_mday,
-           t.tm_hour, t.tm_min, &t.tm_sec);
+           t.tm_hour, t.tm_min, t.tm_sec);
         if (t.tm_year < 70)
         t.tm_year += 100; /* base year of 1900 */
     t.tm_mon--;
     epoch_base = mktime(&t);
-    printf("epoch base = %d\n", epoch_base);
+    printf("epoch base = %ld\n", epoch_base);
     return 0;
 
 }

--- a/Renesas/cs+/RH850/rsapss_sign_verify/example_main.c
+++ b/Renesas/cs+/RH850/rsapss_sign_verify/example_main.c
@@ -91,7 +91,7 @@ size_t  _REL_sizeof_sysheap = SIZEOF_HEAP;
 
 void main(void)
 {
-   byte ret;
+   int ret;
    
    R_SYSTEM_ClockInit();
    R_SYSTEM_TimerInit();

--- a/Renesas/cs+/RH850/rsapss_sign_verify/rsapss.c
+++ b/Renesas/cs+/RH850/rsapss_sign_verify/rsapss.c
@@ -108,18 +108,19 @@ static int load_rsa_private_key(RsaKey* pRsaKey)
 static int sign_with_rsa_key(RsaKey* pRsaKey, WC_RNG* rng, const char* msg)
 {
     int ret;
-    
+
     /* Hash message to b signed */
-    if (hash_msg(msg, hash) != 0 ) {
+    ret = hash_msg(msg, hash);
+    if (ret != 0 ) {
         goto sign_end;
     }
-    
+
     printf("Signing hash of message\n");
     /* RSA-PSS sign */
     ret = wc_RsaPSS_Sign(hash, sizeof(hash), pSignature, sizeof(pSignature),
         WC_HASH_TYPE_SHA256, WC_MGF1SHA256, pRsaKey, rng);
     if (ret <= 0) {
-        printf("  RSA private encryption failed with error %d\n");
+        printf("  RSA private encryption failed with error %d\n", ret);
         goto sign_end;
     }
     
@@ -135,7 +136,8 @@ static int verify_with_rsa_public_key(RsaKey* pRsaKey, const char* msg)
     byte  pDecrypted[RSA_KEY_SIZE/8];
     byte* pt;
     /* Hash message to be signed. */
-    if (hash_msg(msg, hash) != 0) {
+    ret = hash_msg(msg, hash);
+    if (ret != 0) {
         goto verify_end;
     }
     

--- a/SGX_Linux/trusted/Wolfssl_Enclave.c
+++ b/SGX_Linux/trusted/Wolfssl_Enclave.c
@@ -336,7 +336,7 @@ int enc_wolfSSL_Cleanup(void)
     /* free up all WOLFSSL_CTX's */
     for (id = 0; id < MAX_WOLFSSL_CTX; id++)
         RemoveCTX(id);
-    wolfSSL_Cleanup();
+    return wolfSSL_Cleanup();
 }
 
 void printf(const char *fmt, ...)
@@ -347,16 +347,6 @@ void printf(const char *fmt, ...)
     vsnprintf(buf, BUFSIZ, fmt, ap);
     va_end(ap);
     ocall_print_string(buf);
-}
-
-int sprintf(char* buf, const char *fmt, ...)
-{
-    va_list ap;
-    int ret;
-    va_start(ap, fmt);
-    ret = vsnprintf(buf, BUFSIZ, fmt, ap);
-    va_end(ap);
-    return ret;
 }
 
 double current_time(void)

--- a/SGX_Linux/trusted/Wolfssl_Enclave.h
+++ b/SGX_Linux/trusted/Wolfssl_Enclave.h
@@ -27,7 +27,6 @@ extern "C" {
 #endif
 
 void printf(const char *fmt, ...);
-int sprintf(char* buf, const char *fmt, ...);
 double current_time(void);
 
 #if defined(__cplusplus)

--- a/TOPPERS/README-en.md
+++ b/TOPPERS/README-en.md
@@ -123,6 +123,12 @@ If you have used the smart configurator to generate code for [r_bsp],[r_cmt_rx],
 Note:<br>
 `T4_Library_ether_ccrx_rxv1_little` may be an error in the linker immediately after configuration/build Clear There is, but `T4_Library_ether_ccrx_rxv1_little`` from [Linker]/[Archives]/[User defined archive (library) files (-I)]/[×] in [Settings] of the [Properties] dialog [C/C++ Build] of the project. Please delete it.
 
+3-10. Local Verification of ECC Configuration (USE_ECC_CERT)
+
+To locally compile and verify the build with ECC certificate support:
+1. Define the macro `USE_ECC_CERT` in `TOPPERS/WolfSSLDemo/src/wolfDemo/user_settings.h` (e.g., `#define USE_ECC_CERT`) or add it to the compiler preprocessor macros list in the e² studio project configuration.
+2. Build the project as described in step 3-8 to ensure that the code under `#if defined(USE_ECC_CERT)` compiles without errors.
+
 ### 3-1 Run Server Program
 
 3-1-1. Enable `#define WOLFSSL_SERVER_TEST` in `wolf_demo.h`. IP addres will be assigned by DHCP.

--- a/TOPPERS/WolfSSLDemo/src/wolfDemo/wolf_client.c
+++ b/TOPPERS/WolfSSLDemo/src/wolfDemo/wolf_client.c
@@ -160,7 +160,7 @@ int wolfSSL_TLS_client(void *v_ctx, func_args *args)
                                         cliecc_cert_der_256,
                                         sizeof_cliecc_cert_der_256,
                                         WOLFSSL_FILETYPE_ASN1);
-        if(err != SSL_SUCCESS) {
+        if(ret != SSL_SUCCESS) {
             printf("ERROR: can't load client-certificate\n");
             ret = -1;
             goto exit_;

--- a/caam/seco/cryptodev/ecc-sign-verify.c
+++ b/caam/seco/cryptodev/ecc-sign-verify.c
@@ -93,7 +93,11 @@ static int createSignature(ecc_key* key, byte* sigOut, word32* sigOutSz,
     int ret;
     WC_RNG rng;
 
-    wc_InitRng(&rng);
+    ret = wc_InitRng(&rng);
+    if (ret != 0) {
+        printf("wc_InitRng failed with error %d\n", ret);
+        return ret;
+    }
     ret = wc_ecc_sign_hash(msg, msgSz, sigOut, sigOutSz, &rng, key);
     if (ret != 0) {
         printf("sign hash failed with error %d\n", ret);
@@ -164,7 +168,12 @@ int main(int argc, char** argv)
         printf("Could not initialize wolfSSL library!\n");
         return -1;
     }
-    wc_InitRng(&rng);
+    ret = wc_InitRng(&rng);
+    if (ret != 0) {
+        printf("wc_InitRng failed with error %d\n", ret);
+        wolfCrypt_Cleanup();
+        return -1;
+    }
 
     XMEMSET(sig, 0, sigSz);
     ret = createEccKey(&rng, &hardKey, 32, WOLFSSL_CAAM_DEVID);

--- a/caam/seco/cryptodev/ecdh.c
+++ b/caam/seco/cryptodev/ecdh.c
@@ -97,7 +97,12 @@ int main(int argc, char** argv)
         return -1;
     }
 
-    wc_InitRng(&rng);
+    ret = wc_InitRng(&rng);
+    if (ret != 0) {
+        printf("wc_InitRng failed with error %d\n", ret);
+        wolfCrypt_Cleanup();
+        return -1;
+    }
 
     ret = createEccKey(&rng, &hwKey, WOLFSSL_CAAM_DEVID);
     if (ret != 0) {

--- a/caam/seco/import-key.c
+++ b/caam/seco/import-key.c
@@ -158,6 +158,9 @@ int main(int argc, char** argv)
 
     TestAesCbc(&enc, &dec);
 
+    wc_AesFree(&enc);
+    wc_AesFree(&dec);
+
     wc_SECO_CloseHSM();
     wolfCrypt_Cleanup();
     return 0;

--- a/fullstack/freertos-wolfip-wolfssl-https/src/wolfip_freertos.c
+++ b/fullstack/freertos-wolfip-wolfssl-https/src/wolfip_freertos.c
@@ -21,6 +21,7 @@
 
 #include "wolfip_freertos.h"
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
 #include <fcntl.h>
@@ -36,8 +37,20 @@
 
 /* Implementation of wolfIP's required random number generator */
 uint32_t wolfIP_getrandom(void) {
-    uint32_t ret;
-    getrandom(&ret, sizeof(ret), 0);
+    uint32_t ret = 0;
+    size_t got = 0;
+
+    while (got < sizeof(ret)) {
+        ssize_t r = getrandom(((uint8_t*)&ret) + got, sizeof(ret) - got, 0);
+        if (r <= 0) {
+            if (r < 0 && errno == EINTR) {
+                continue;
+            }
+            fprintf(stderr, "getrandom() failed, aborting\n");
+            abort();
+        }
+        got += (size_t)r;
+    }
     return ret;
 }
 

--- a/lwip/example-lwip-native-echoclient.c
+++ b/lwip/example-lwip-native-echoclient.c
@@ -65,7 +65,7 @@
 #endif
 
 #ifndef MAX_MSG_SIZE
-#define MAX_MSG_SIZE
+#define MAX_MSG_SIZE 1024
 #endif
 
 #define TEST_MSG "TLS **TEST 1** "
@@ -127,7 +127,7 @@ void tls_echoclient_connect(void)
         /* read a reply from the server */
         if (tlsWaitingForReply == 1) {
             memset(reply, 0, sizeof(reply));
-            ret = wolfSSL_read(ssl, reply, sizeof(reply));
+            ret = wolfSSL_read(ssl, reply, sizeof(reply) - 1);
             if (ret <= 0) {
                 err = wolfSSL_get_error(ssl, 0);
                 if (err != SSL_ERROR_WANT_READ &&
@@ -137,6 +137,7 @@ void tls_echoclient_connect(void)
                 }
             }
             if (ret > 0) {
+                reply[ret] = '\0';
                 loggingCb(0, reply);
                 shutdown(); /* received reply, done with connection */
             }
@@ -181,10 +182,7 @@ static int TLS_setup(void)
         return ERR_MEM;
     }
 
-#if 1
-    /* Disable peer certificate validation for testing */
-    wolfSSL_CTX_set_verify(ctx, WOLFSSL_VERIFY_NONE, NULL);
-#endif
+    wolfSSL_CTX_set_verify(ctx, WOLFSSL_VERIFY_PEER, NULL);
 
     ssl = wolfSSL_new(ctx);
     if (ssl == NULL) {

--- a/mynewt/client-tls-mn.c
+++ b/mynewt/client-tls-mn.c
@@ -35,7 +35,6 @@
 
 #include <shell/shell.h>
 #include <mn_socket/mn_socket.h>
-// #include <inet_def_service/inet_def_service.h>
 
 #include <assert.h>
 #include <string.h>
@@ -57,7 +56,7 @@ extern time_t time(time_t*);
 #define USE_CERT_BUFFERS_2048
 #include <wolfssl/certs_test.h>
 
-#define DEFAULT_IPADDR "93.184.216.34" // www.example.com
+#define DEFAULT_IPADDR "93.184.216.34" /* www.example.com */
 #define DEFAULT_PORT 443
 
 struct os_sem test_sem;
@@ -173,11 +172,11 @@ net_cli(int argc, char **argv)
         int port = DEFAULT_PORT;
 
         if(argc > 3) {
-            // get ip address from argument
+            /* get ip address from argument */
             addrStr = argv[2];
         }
         if(argc > 4) {
-            // get port number from argument
+            /* get port number from argument */
             char *eptr = NULL;
             port = strtoul(argv[3], &eptr, 0);
             if (*eptr != '\0') {
@@ -381,7 +380,7 @@ static WOLFSSL*     ssl = NULL;
 static int wolfssl_ctx_init() {
     if(wolfsslCtx && ssl) {
         console_printf("ERROR: already initialize WOLFSSL_CTX and ssl\n");
-        return -1; // already init
+        return -1; /* already init */
     }
 
     /* Create and initialize WOLFSSL_CTX */

--- a/psk/server-psk-tls13-multi-id.c
+++ b/psk/server-psk-tls13-multi-id.c
@@ -194,8 +194,8 @@ int main()
             if (n > 0) {
                 printf("%s\n", buf);
                 /* server response */
-                if (wolfSSL_write(ssl, response, strlen(response)) >
-                    strlen(response)) {
+                if (wolfSSL_write(ssl, response, strlen(response)) !=
+                    (int)strlen(response)) {
                     printf("Fatal error : respond: write error\n");
                     return 1;
                 }

--- a/stsafe/platform/stse_platform_linux.c
+++ b/stsafe/platform/stse_platform_linux.c
@@ -121,6 +121,9 @@ stse_ReturnCode_t stse_platform_i2c_send_continue(
     (void)speed;
 
     if (data_size != 0) {
+        if ((PLAT_UI32)i2c_tx_frame_offset + data_size > I2C_BUFFER_SIZE) {
+            return STSE_PLATFORM_BUFFER_ERR;
+        }
         if (pData == NULL) {
             memset((I2c_tx_buffer + i2c_tx_frame_offset), 0x00, data_size);
         } else {
@@ -150,6 +153,9 @@ stse_ReturnCode_t stse_platform_i2c_send_stop(
 
     /* Add final element if provided */
     if (pElement != NULL && element_size > 0) {
+        if ((PLAT_UI32)i2c_tx_frame_offset + element_size > I2C_BUFFER_SIZE) {
+            return STSE_PLATFORM_BUFFER_ERR;
+        }
         memcpy((I2c_tx_buffer + i2c_tx_frame_offset), pElement, element_size);
         i2c_tx_frame_offset += element_size;
     }
@@ -203,6 +209,7 @@ stse_ReturnCode_t stse_platform_i2c_send(
     return STSE_OK;
 }
 
+/* \note pFrame_payload must be at least I2C_BUFFER_SIZE bytes. */
 stse_ReturnCode_t stse_platform_i2c_receive(
     PLAT_UI8 busID,
     PLAT_UI8 devAddr,
@@ -242,6 +249,11 @@ stse_ReturnCode_t stse_platform_i2c_receive(
     }
 
     PLAT_UI16 payload_len = ((PLAT_UI16)len_bytes[0] << 8) | len_bytes[1];
+
+    if (payload_len > I2C_BUFFER_SIZE) {
+        return STSE_PLATFORM_BUFFER_ERR;
+    }
+
     *pFrame_payload_Length = payload_len;
 
     if (payload_len > 0 && pFrame_payload != NULL) {

--- a/uefi-library/src/utility_wolf.c
+++ b/uefi-library/src/utility_wolf.c
@@ -83,16 +83,16 @@ unsigned int calculateBufferSize(const char* msg, va_list args)
 
     while (*p) {
         if (*p == '%' && *(p + 1)) {
-            p++; // Move past '%'
-            if (*p == 's' || *p == 'a') { // Handle strings
+            p++; /* Move past '%' */
+            if (*p == 's' || *p == 'a') { /* Handle strings */
                 char* str = va_arg(args_copy, char*);
                 if (str) {
-                    size += XSTRLEN(str); // Add the length of the string
+                    size += XSTRLEN(str); /* Add the length of the string */
                 }
             } else if (*p == 'd' || *p == 'u' || *p == 'x') {
-                va_arg(args_copy, int); // Skip integers
+                va_arg(args_copy, int); /* Skip integers */
             } else if (*p == 'f') {
-                va_arg(args_copy, double); // Skip doubles
+                va_arg(args_copy, double); /* Skip doubles */
             }
         }
         p++;
@@ -527,7 +527,7 @@ FILE* fopen(const char* filename, const char* mode)
 
     parseAndReplace(filename, temp, "/", "\\");
     uefi_printf_wolfssl("Filename After: %s\n", filename);
-    //parseAndReplace(filename, temp, "./", "\\");
+    /* parseAndReplace(filename, temp, "./", "\\"); */
 #else
     temp = (char*)filename;
 #endif
@@ -628,6 +628,7 @@ int fclose(FILE* stream)
     int ret = -1;
     (void)stream;
     EFI_FILE_HANDLE* fPtr = NULL;
+    EFI_STATUS status;
 
     uefi_printf_debug("Inside custom fclose\n");
     if (stream == NULL) {
@@ -636,7 +637,8 @@ int fclose(FILE* stream)
     }
     fPtr = (EFI_FILE_HANDLE*)stream;
 
-    uefi_call_wrapper((*fPtr)->Close, 1, *fPtr);
+    status = uefi_call_wrapper((*fPtr)->Close, 1, *fPtr);
+    ret = EFI_ERROR(status) ? -1 : 0;
 
 
     XFREE(fPtr, NULL, DYNAMIC_TYPE_TMP_BUFFER);
@@ -730,7 +732,7 @@ long ftell(FILE* stream)
     fPtr = (EFI_FILE_HANDLE*)stream;
 
     fSize = fileSize(*(fPtr));
-    if (fileSize == 0) {
+    if (fSize == 0) {
         uefi_printf_wolfssl("File is of size 0\n");
         return 0;
     }
@@ -756,7 +758,7 @@ size_t fread(void* ptr, size_t size, size_t count, FILE* stream)
     fPtr = (EFI_FILE_HANDLE*)stream;
 
     fSize = fileSize(*(fPtr));
-    if (fileSize == 0) {
+    if (fSize == 0) {
         uefi_printf_wolfssl("File is of size 0\n");
         return 0;
     }
@@ -1043,7 +1045,7 @@ size_t fwrite(const void* ptr, size_t size, size_t count, FILE* stream)
 {
     size_t ret = 0; /* Number of items successfully written */
     EFI_FILE_HANDLE* fPtr = NULL;
-    //UINTN totalBytes = count * size * 8; /* Total bytes to write */
+    /* UINTN totalBytes = count * size * 8; -- Total bytes to write */
     EFI_STATUS status;
     uefi_printf_debug("Inside custom fwrite\n");
 
@@ -1103,8 +1105,9 @@ struct dirent* readdir(DIR* stream)
     }
 
     fSize = fileSize(*(fPtr));
-    if (fileSize == 0) {
+    if (fSize == 0) {
         uefi_printf_wolfssl("File is of size 0\n");
+        XFREE(dirPtr, NULL, DYNAMIC_TYPE_TMP_BUFFER);
         return 0;
     }
 
@@ -1334,7 +1337,7 @@ unsigned long long current_time(int reset)
 
     /* Convert to total seconds */
     unsigned long long total_seconds =
-        //(days_since_epoch * 86400) + // Uncomment to return epoch time
+        /* (days_since_epoch * 86400) + -- Uncomment to return epoch time */
         (time_uefi.Hour * 3600) +
         (time_uefi.Minute * 60) +
         time_uefi.Second;

--- a/uefi-static/main.c
+++ b/uefi-static/main.c
@@ -13,10 +13,16 @@
 
 #define uefi_printf(_f_, ...) Print(L##_f_, ##__VA_ARGS__)
 
-void char8_to_char16(const char* str8, wchar_t* str16)
+void char8_to_char16(const char* str8, wchar_t* str16, size_t cap)
 {
 	size_t i;
 	size_t size_str8 = strlen(str8);
+	if (cap == 0) {
+		return;
+	}
+	if (size_str8 > cap - 1) {
+		size_str8 = cap - 1;
+	}
 	for (i = 0; i < size_str8; ++i) {
 		str16[i] = (wchar_t)str8[i];
 	}
@@ -26,7 +32,7 @@ void char8_to_char16(const char* str8, wchar_t* str16)
 void logging_cb(const int logLevel, const char *const logMessage)
 {
 	wchar_t str16[STR_SIZE];
-	char8_to_char16(logMessage, str16);
+	char8_to_char16(logMessage, str16, STR_SIZE);
     uefi_printf("%s", str16);
 }
 

--- a/utasker/wolfSSLClientTask.c
+++ b/utasker/wolfSSLClientTask.c
@@ -388,6 +388,7 @@ extern void fnTLSClientTask(TTASKTABLE *ptrTaskTable)
         if (sslCtx == NULL) {
             fnDebugMsg("ERROR: wolfSSL_CTX_new() failed\r\n");
             clientState = clientShutdown;
+            return;
         }
         else {
             fnDebugMsg("status: Created WOLFSSL_CTX\r\n");
@@ -404,6 +405,7 @@ extern void fnTLSClientTask(TTASKTABLE *ptrTaskTable)
         if (ret != SSL_SUCCESS) {
             fnDebugMsg("ERROR: wolfSSL_CTX_load_verify_buffer\r\n");
             clientState = clientShutdown;
+            return;
         }
         else {
             fnDebugMsg("status: Loaded trusted CA certificates\r\n");
@@ -428,6 +430,7 @@ extern void fnTLSClientTask(TTASKTABLE *ptrTaskTable)
         if (ssl == NULL) {
             fnDebugMsg("ERROR: wolfSSL_new\r\n");
             clientState = clientShutdown;
+            return;
         }
         else {
             fnDebugMsg("status: Created WOLFSSL session object\r\n");

--- a/utasker/wolfSSLServerTask.c
+++ b/utasker/wolfSSLServerTask.c
@@ -104,6 +104,7 @@ int CacheRecvBuffer(UTASKER_RECVCTX* ctx, unsigned char* data,
 int ResetRecvBuffer(UTASKER_RECVCTX* ctx);
 int UTasker_Receive(WOLFSSL* ssl, char* buf, int sz, void* ctx);
 int UTasker_Send(WOLFSSL* ssl, char* buf, int sz, void* ctx);
+static void AbortServerTLSInit(void);
 
 /* ---------------------------- SOCKET LISTENERS --------------------------- */
 
@@ -171,6 +172,18 @@ static int fnServerListener(USOCKET Socket, unsigned char ucEvent,
 
 /* ------------------------------- APP TASK -------------------------------- */
 
+/*
+ * release resources acquired so far during serverTLSInit and abort setup
+ */
+static void AbortServerTLSInit(void)
+{
+    if (sslCtx != NULL) {
+        wolfSSL_CTX_free(sslCtx);
+        sslCtx = NULL;
+    }
+    wolfSSL_Cleanup();
+    serverState = serverIdle;
+}
 
 /*
  * wolfSSL server app task
@@ -208,7 +221,8 @@ extern void fnTLSServerTask(TTASKTABLE *ptrTaskTable)
         sslCtx = wolfSSL_CTX_new(wolfTLSv1_2_server_method());
         if (sslCtx == NULL) {
             fnDebugMsg("ERROR: wolfSSL_CTX_new() failed\r\n");
-            serverState = serverShutdown;
+            AbortServerTLSInit();
+            return;
         }
         else {
             fnDebugMsg("status: Created WOLFSSL_CTX\r\n");
@@ -220,7 +234,8 @@ extern void fnTLSServerTask(TTASKTABLE *ptrTaskTable)
             SSL_FILETYPE_ASN1);
         if (ret != SSL_SUCCESS) {
             fnDebugMsg("ERROR: wolfSSL_CTX_use_certificate_chain_buffer\r\n");
-            serverState = serverShutdown;
+            AbortServerTLSInit();
+            return;
         }
 
         /* load server private key */
@@ -229,7 +244,8 @@ extern void fnTLSServerTask(TTASKTABLE *ptrTaskTable)
             SSL_FILETYPE_ASN1);
         if (ret != SSL_SUCCESS) {
             fnDebugMsg("ERROR: wolfSSL_CTX_use_PrivateKey_buffer\r\n");
-            serverState = serverShutdown;
+            AbortServerTLSInit();
+            return;
         }
 
         /* register wolfSSL send/recv callbacks */
@@ -268,6 +284,7 @@ extern void fnTLSServerTask(TTASKTABLE *ptrTaskTable)
         if (ssl == NULL) {
             fnDebugMsg("ERROR: wolfSSL_new\r\n");
             serverState = serverShutdown;
+            return;
         }
         else {
             fnDebugMsg("status: Created WOLFSSL session object\r\n");


### PR DESCRIPTION
Addresses a batch of platform/hardware-specific bugs found across the examples tree:

- CAAM/SECO, Renesas RH850, STSafe, UEFI, uTasker: missing return-value/error checks, bounds checks on device-supplied lengths, and buffer-size fixes
- SGX_Linux: enc_wolfSSL_Cleanup now returns its result, removed a stray unsafe enclave sprintf
- wolfIP/FreeRTOS: hardened wolfIP_getrandom() retry loop against EINTR and zero-byte reads
- RPi-Pico, lwIP, Mynewt, PSK, TOPPERS: assorted correctness fixes plus