### PR TITLE
pkcs11_test.c: fix uninitialized

### DIFF
--- a/pkcs11/pkcs11_test.c
+++ b/pkcs11/pkcs11_test.c
@@ -272,7 +272,7 @@ int get_public_key(RsaKey* key, Pkcs11Token* token, CK_SESSION_HANDLE session,
     int ret = 0;
     unsigned char* mod = NULL;
     unsigned char* exp = NULL;
-    int modSz, expSz;
+    int modSz = 0, expSz = 0;
     CK_ATTRIBUTE template[] = {
       {CKA_MODULUS, NULL_PTR, 0},
       {CKA_PUBLIC_EXPONENT, NULL_PTR, 0}


### PR DESCRIPTION
Some compilers believe that modSz and expSz may be uninitialized at use.
Initialize to 0 to stop warnings.